### PR TITLE
make no-new-require recommended

### DIFF
--- a/lib/rules/no-new-require.js
+++ b/lib/rules/no-new-require.js
@@ -10,7 +10,7 @@ module.exports = {
         docs: {
             description: "disallow `new` operators with calls to `require`",
             category: "Possible Errors",
-            recommended: false,
+            recommended: true,
             url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-new-require.md",
         },
         fixable: null,


### PR DESCRIPTION
I propose making `n/no-new-require` a recommended rule b/c it only makes cjs tuffer to refactor code to ESM at some point later in the feature.