### PR TITLE
Add support for modules

### DIFF
--- a/lib/rules/no-unsupported-features/es-syntax.js
+++ b/lib/rules/no-unsupported-features/es-syntax.js
@@ -126,7 +126,7 @@ const features = {
         ruleId: "no-modules",
         cases: [
             {
-                supported: null,
+                supported: "13.2.0",
                 messageId: "no-modules",
             },
         ],


### PR DESCRIPTION
First off, much appreciated for forking and landing #13.  I tested out this package but was still hitting issues around top level exports.  I was able to narrow it down and fix by adding supported version of 13.2.0 to modules.  As you can see [here](https://github.com/nodejs/node/pull/29866), this is when they removed the experimental flag.  [13.2.0 Changelog](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V13.md#2019-11-21-version-1320-current-mylesborins). I tested this locally and no longer see the following error:

```sh
  10:1  error  Import and export declarations are not supported yet  n/no-unsupported-features/es-syntax
```
