### PR TITLE
feat: Disable the `no-unpublished-x` rules in private packages

### DIFF
--- a/lib/util/check-publish.js
+++ b/lib/util/check-publish.js
@@ -26,6 +26,12 @@ exports.checkPublish = function checkPublish(context, filePath, targets) {
         return
     }
 
+    // Private packages are never published so we don't need to check the imported dependencies either.
+    // More information: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#private
+    if (packageInfo.private === true) {
+        return
+    }
+
     const allowed = new Set(getAllowModules(context))
     const convertPath = getConvertPath(context)
     const basedir = path.dirname(packageInfo.filePath)

--- a/tests/fixtures/no-extraneous/dependencies/package.json
+++ b/tests/fixtures/no-extraneous/dependencies/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "version": "0.0.0",
     "dependencies": {

--- a/tests/fixtures/no-extraneous/noDependencies/package.json
+++ b/tests/fixtures/no-extraneous/noDependencies/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "version": "0.0.0"
 }

--- a/tests/fixtures/no-extraneous/optionalDependencies/package.json
+++ b/tests/fixtures/no-extraneous/optionalDependencies/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "version": "0.0.0",
     "optionalDependencies": {

--- a/tests/fixtures/no-extraneous/peerDependencies/package.json
+++ b/tests/fixtures/no-extraneous/peerDependencies/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "version": "0.0.0",
     "peerDependencies": {

--- a/tests/fixtures/no-unpublished-bin/issue115/package.json
+++ b/tests/fixtures/no-unpublished-bin/issue115/package.json
@@ -1,7 +1,10 @@
 {
-    "private": true,
     "name": "test",
     "version": "1.0.0",
-    "bin": {"a": "lib/a.js"},
-    "files": ["lib/a.js"]
+    "bin": {
+        "a": "lib/a.js"
+    },
+    "files": [
+        "lib/a.js"
+    ]
 }

--- a/tests/fixtures/no-unpublished-bin/multi-files/package.json
+++ b/tests/fixtures/no-unpublished-bin/multi-files/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "version": "1.0.0",
     "bin": {

--- a/tests/fixtures/no-unpublished-bin/multi-npmignore/package.json
+++ b/tests/fixtures/no-unpublished-bin/multi-npmignore/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "version": "1.0.0",
     "bin": {

--- a/tests/fixtures/no-unpublished-bin/simple-files/package.json
+++ b/tests/fixtures/no-unpublished-bin/simple-files/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "version": "1.0.0",
     "bin": "a.js",

--- a/tests/fixtures/no-unpublished-bin/simple-npmignore/package.json
+++ b/tests/fixtures/no-unpublished-bin/simple-npmignore/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "version": "1.0.0",
     "bin": "a.js"

--- a/tests/fixtures/no-unpublished-bin/simple-ok/package.json
+++ b/tests/fixtures/no-unpublished-bin/simple-ok/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "version": "1.0.0",
     "bin": "a.js"

--- a/tests/fixtures/no-unpublished/1/package.json
+++ b/tests/fixtures/no-unpublished/1/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "version": "0.0.0",
     "dependencies": {

--- a/tests/fixtures/no-unpublished/2/package.json
+++ b/tests/fixtures/no-unpublished/2/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "version": "0.0.0",
     "dependencies": {

--- a/tests/fixtures/no-unpublished/3/package.json
+++ b/tests/fixtures/no-unpublished/3/package.json
@@ -1,8 +1,9 @@
 {
-    "private": true,
     "name": "test",
     "version": "0.0.0",
-    "files": ["pub"],
+    "files": [
+        "pub"
+    ],
     "dependencies": {
         "aaa": "0.0.0"
     },

--- a/tests/fixtures/no-unpublished/issue126/package.json
+++ b/tests/fixtures/no-unpublished/issue126/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "version": "0.0.0",
     "files": [

--- a/tests/fixtures/no-unpublished/negative-in-files/package.json
+++ b/tests/fixtures/no-unpublished/negative-in-files/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "version": "0.0.0",
     "files": [

--- a/tests/fixtures/no-unpublished/private-package/package.json
+++ b/tests/fixtures/no-unpublished/private-package/package.json
@@ -1,8 +1,8 @@
 {
+    "private": true,
     "name": "test",
     "version": "0.0.0",
     "devDependencies": {
-        "aaa": "0.0.0",
-        "@bbb/aaa": "0.0.0"
+        "bbb": "0.0.0"
     }
 }

--- a/tests/fixtures/no-unsupported-features--ecma/gte-0.12.8/package.json
+++ b/tests/fixtures/no-unsupported-features--ecma/gte-0.12.8/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "engines": {
         "node": ">=0.12.8"

--- a/tests/fixtures/no-unsupported-features--ecma/gte-4.0.0/package.json
+++ b/tests/fixtures/no-unsupported-features--ecma/gte-4.0.0/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "engines": {
         "node": ">=4.0.0"

--- a/tests/fixtures/no-unsupported-features--ecma/gte-4.4.0-lt-5.0.0/package.json
+++ b/tests/fixtures/no-unsupported-features--ecma/gte-4.4.0-lt-5.0.0/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "engines": {
         "node": ">=4.4.0 <5.0.0"

--- a/tests/fixtures/no-unsupported-features--ecma/gte-7.10.0/package.json
+++ b/tests/fixtures/no-unsupported-features--ecma/gte-7.10.0/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "engines": {
         "node": ">=7.10.0"

--- a/tests/fixtures/no-unsupported-features--ecma/gte-7.5.0/package.json
+++ b/tests/fixtures/no-unsupported-features--ecma/gte-7.5.0/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "engines": {
         "node": ">=7.5.0"

--- a/tests/fixtures/no-unsupported-features--ecma/gte-7.6.0/package.json
+++ b/tests/fixtures/no-unsupported-features--ecma/gte-7.6.0/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "engines": {
         "node": ">=7.6.0"

--- a/tests/fixtures/no-unsupported-features--ecma/hat-4.1.2/package.json
+++ b/tests/fixtures/no-unsupported-features--ecma/hat-4.1.2/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "engines": {
         "node": "^4.1.2"

--- a/tests/fixtures/no-unsupported-features--ecma/invalid/package.json
+++ b/tests/fixtures/no-unsupported-features--ecma/invalid/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "engines": {
         "node": "foo-bar"

--- a/tests/fixtures/no-unsupported-features--ecma/lt-6.0.0/package.json
+++ b/tests/fixtures/no-unsupported-features--ecma/lt-6.0.0/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "engines": {
         "node": "<6.0.0"

--- a/tests/fixtures/no-unsupported-features--ecma/nothing/package.json
+++ b/tests/fixtures/no-unsupported-features--ecma/nothing/package.json
@@ -1,4 +1,3 @@
 {
-    "private": true,
     "name": "test"
 }

--- a/tests/fixtures/no-unsupported-features--ecma/star/package.json
+++ b/tests/fixtures/no-unsupported-features--ecma/star/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "engines": {
         "node": "*"

--- a/tests/fixtures/no-unsupported-features--ecma/without-node/package.json
+++ b/tests/fixtures/no-unsupported-features--ecma/without-node/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "engines": {
         "vscode": "foo"

--- a/tests/fixtures/no-unsupported-features/gte-0.12.8/package.json
+++ b/tests/fixtures/no-unsupported-features/gte-0.12.8/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "engines": {
         "node": ">=0.12.8"

--- a/tests/fixtures/no-unsupported-features/gte-4.0.0/package.json
+++ b/tests/fixtures/no-unsupported-features/gte-4.0.0/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "engines": {
         "node": ">=4.0.0"

--- a/tests/fixtures/no-unsupported-features/gte-4.4.0-lt-5.0.0/package.json
+++ b/tests/fixtures/no-unsupported-features/gte-4.4.0-lt-5.0.0/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "engines": {
         "node": ">=4.4.0 <5.0.0"

--- a/tests/fixtures/no-unsupported-features/gte-7.10.0/package.json
+++ b/tests/fixtures/no-unsupported-features/gte-7.10.0/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "engines": {
         "node": ">=7.10.0"

--- a/tests/fixtures/no-unsupported-features/gte-7.5.0/package.json
+++ b/tests/fixtures/no-unsupported-features/gte-7.5.0/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "engines": {
         "node": ">=7.5.0"

--- a/tests/fixtures/no-unsupported-features/gte-7.6.0/package.json
+++ b/tests/fixtures/no-unsupported-features/gte-7.6.0/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "engines": {
         "node": ">=7.6.0"

--- a/tests/fixtures/no-unsupported-features/hat-4.1.2/package.json
+++ b/tests/fixtures/no-unsupported-features/hat-4.1.2/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "engines": {
         "node": "^4.1.2"

--- a/tests/fixtures/no-unsupported-features/invalid/package.json
+++ b/tests/fixtures/no-unsupported-features/invalid/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "engines": {
         "node": "foo-bar"

--- a/tests/fixtures/no-unsupported-features/lt-6.0.0/package.json
+++ b/tests/fixtures/no-unsupported-features/lt-6.0.0/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "engines": {
         "node": "<6.0.0"

--- a/tests/fixtures/no-unsupported-features/nothing/package.json
+++ b/tests/fixtures/no-unsupported-features/nothing/package.json
@@ -1,4 +1,3 @@
 {
-    "private": true,
     "name": "test"
 }

--- a/tests/fixtures/no-unsupported-features/without-node/package.json
+++ b/tests/fixtures/no-unsupported-features/without-node/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "engines": {
         "vscode": "foo"

--- a/tests/fixtures/shebang/no-bin-field/package.json
+++ b/tests/fixtures/shebang/no-bin-field/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "version": "0.0.0"
 }

--- a/tests/fixtures/shebang/object-bin/package.json
+++ b/tests/fixtures/shebang/object-bin/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "version": "0.0.0",
     "bin": {

--- a/tests/fixtures/shebang/string-bin/package.json
+++ b/tests/fixtures/shebang/string-bin/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "name": "test",
     "version": "0.0.0",
     "bin": "./bin/test.js"

--- a/tests/lib/rules/no-unpublished-import.js
+++ b/tests/lib/rules/no-unpublished-import.js
@@ -145,6 +145,12 @@ ruleTester.run("no-unpublished-import", rule, {
             filename: fixture("negative-in-files/lib/__test__/index.js"),
             code: "import bbb from 'bbb';",
         },
+
+        // devDependency in a private package
+        {
+            filename: fixture("private-package/index.js"),
+            code: "import bbb from 'bbb';",
+        },
     ],
     invalid: [
         {

--- a/tests/lib/rules/no-unpublished-require.js
+++ b/tests/lib/rules/no-unpublished-require.js
@@ -266,6 +266,13 @@ ruleTester.run("no-unpublished-require", rule, {
             code: "require('bbb');",
             env: { node: true },
         },
+
+        // devDependency in a private package
+        {
+            filename: fixture("private-package/index.js"),
+            code: "require('bbb');",
+            env: { node: true },
+        },
     ],
     invalid: [
         {


### PR DESCRIPTION
Private packages are never published so the `no-unpublished-import` and `no-unpublished-require` rules don't need to run.

More information: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#private

This fixes the original issue from the eslint-plugin-node repo: https://github.com/mysticatea/eslint-plugin-node/issues/77

~~It seems a lot of tests fail because their test fixture setups contain `package.json` files with `private: true` set. I think that is just an issue with those textures and `private: true` should be removed there?~~ I removed `"private": true` where needed.