### PR TITLE
fix: consider node: prefix in prefer-global rules

### DIFF
--- a/lib/util/check-prefer-global.js
+++ b/lib/util/check-prefer-global.js
@@ -34,9 +34,19 @@ class Verifier {
             mode: "legacy",
         })
 
+        const modules = {
+            ...trackMap.modules,
+            ...Object.fromEntries(
+                Object.entries(trackMap.modules).map(([name, value]) => [
+                    `node:${name}`,
+                    value,
+                ])
+            ),
+        }
+
         for (const { node } of [
-            ...tracker.iterateCjsReferences(trackMap.modules),
-            ...tracker.iterateEsmReferences(trackMap.modules),
+            ...tracker.iterateCjsReferences(modules),
+            ...tracker.iterateEsmReferences(modules),
         ]) {
             context.report({ node, messageId: "preferGlobal" })
         }

--- a/tests/lib/rules/prefer-global/buffer.js
+++ b/tests/lib/rules/prefer-global/buffer.js
@@ -26,6 +26,10 @@ new RuleTester({
             code: "var { Buffer } = require('buffer'); var b = Buffer.alloc(10)",
             options: ["never"],
         },
+        {
+            code: "var { Buffer } = require('node:buffer'); var b = Buffer.alloc(10)",
+            options: ["never"],
+        },
     ],
     invalid: [
         {
@@ -33,7 +37,16 @@ new RuleTester({
             errors: [{ messageId: "preferGlobal" }],
         },
         {
+            code: "var { Buffer } = require('node:buffer'); var b = Buffer.alloc(10)",
+            errors: [{ messageId: "preferGlobal" }],
+        },
+        {
             code: "var { Buffer } = require('buffer'); var b = Buffer.alloc(10)",
+            options: ["always"],
+            errors: [{ messageId: "preferGlobal" }],
+        },
+        {
+            code: "var { Buffer } = require('node:buffer'); var b = Buffer.alloc(10)",
             options: ["always"],
             errors: [{ messageId: "preferGlobal" }],
         },

--- a/tests/lib/rules/prefer-global/console.js
+++ b/tests/lib/rules/prefer-global/console.js
@@ -26,6 +26,10 @@ new RuleTester({
             code: "var console = require('console'); console.log(10)",
             options: ["never"],
         },
+        {
+            code: "var console = require('node:console'); console.log(10)",
+            options: ["never"],
+        },
     ],
     invalid: [
         {
@@ -33,7 +37,16 @@ new RuleTester({
             errors: [{ messageId: "preferGlobal" }],
         },
         {
+            code: "var console = require('node:console'); console.log(10)",
+            errors: [{ messageId: "preferGlobal" }],
+        },
+        {
             code: "var console = require('console'); console.log(10)",
+            options: ["always"],
+            errors: [{ messageId: "preferGlobal" }],
+        },
+        {
+            code: "var console = require('node:console'); console.log(10)",
             options: ["always"],
             errors: [{ messageId: "preferGlobal" }],
         },

--- a/tests/lib/rules/prefer-global/process.js
+++ b/tests/lib/rules/prefer-global/process.js
@@ -26,6 +26,10 @@ new RuleTester({
             code: "var process = require('process'); process.exit(0)",
             options: ["never"],
         },
+        {
+            code: "var process = require('node:process'); process.exit(0)",
+            options: ["never"],
+        },
     ],
     invalid: [
         {
@@ -33,7 +37,16 @@ new RuleTester({
             errors: [{ messageId: "preferGlobal" }],
         },
         {
+            code: "var process = require('node:process'); process.exit(0)",
+            errors: [{ messageId: "preferGlobal" }],
+        },
+        {
             code: "var process = require('process'); process.exit(0)",
+            options: ["always"],
+            errors: [{ messageId: "preferGlobal" }],
+        },
+        {
+            code: "var process = require('node:process'); process.exit(0)",
             options: ["always"],
             errors: [{ messageId: "preferGlobal" }],
         },

--- a/tests/lib/rules/prefer-global/text-decoder.js
+++ b/tests/lib/rules/prefer-global/text-decoder.js
@@ -26,6 +26,10 @@ new RuleTester({
             code: "var { TextDecoder } = require('util'); var b = new TextDecoder(s)",
             options: ["never"],
         },
+        {
+            code: "var { TextDecoder } = require('node:util'); var b = new TextDecoder(s)",
+            options: ["never"],
+        },
     ],
     invalid: [
         {
@@ -33,7 +37,16 @@ new RuleTester({
             errors: [{ messageId: "preferGlobal" }],
         },
         {
+            code: "var { TextDecoder } = require('node:util'); var b = new TextDecoder(s)",
+            errors: [{ messageId: "preferGlobal" }],
+        },
+        {
             code: "var { TextDecoder } = require('util'); var b = new TextDecoder(s)",
+            options: ["always"],
+            errors: [{ messageId: "preferGlobal" }],
+        },
+        {
+            code: "var { TextDecoder } = require('node:util'); var b = new TextDecoder(s)",
             options: ["always"],
             errors: [{ messageId: "preferGlobal" }],
         },

--- a/tests/lib/rules/prefer-global/text-encoder.js
+++ b/tests/lib/rules/prefer-global/text-encoder.js
@@ -26,6 +26,10 @@ new RuleTester({
             code: "var { TextEncoder } = require('util'); var b = new TextEncoder(s)",
             options: ["never"],
         },
+        {
+            code: "var { TextEncoder } = require('node:util'); var b = new TextEncoder(s)",
+            options: ["never"],
+        },
     ],
     invalid: [
         {
@@ -33,7 +37,16 @@ new RuleTester({
             errors: [{ messageId: "preferGlobal" }],
         },
         {
+            code: "var { TextEncoder } = require('node:util'); var b = new TextEncoder(s)",
+            errors: [{ messageId: "preferGlobal" }],
+        },
+        {
             code: "var { TextEncoder } = require('util'); var b = new TextEncoder(s)",
+            options: ["always"],
+            errors: [{ messageId: "preferGlobal" }],
+        },
+        {
+            code: "var { TextEncoder } = require('node:util'); var b = new TextEncoder(s)",
             options: ["always"],
             errors: [{ messageId: "preferGlobal" }],
         },

--- a/tests/lib/rules/prefer-global/url-search-params.js
+++ b/tests/lib/rules/prefer-global/url-search-params.js
@@ -26,6 +26,10 @@ new RuleTester({
             code: "var { URLSearchParams } = require('url'); var b = new URLSearchParams(s)",
             options: ["never"],
         },
+        {
+            code: "var { URLSearchParams } = require('node:url'); var b = new URLSearchParams(s)",
+            options: ["never"],
+        },
     ],
     invalid: [
         {
@@ -33,7 +37,16 @@ new RuleTester({
             errors: [{ messageId: "preferGlobal" }],
         },
         {
+            code: "var { URLSearchParams } = require('node:url'); var b = new URLSearchParams(s)",
+            errors: [{ messageId: "preferGlobal" }],
+        },
+        {
             code: "var { URLSearchParams } = require('url'); var b = new URLSearchParams(s)",
+            options: ["always"],
+            errors: [{ messageId: "preferGlobal" }],
+        },
+        {
+            code: "var { URLSearchParams } = require('node:url'); var b = new URLSearchParams(s)",
             options: ["always"],
             errors: [{ messageId: "preferGlobal" }],
         },

--- a/tests/lib/rules/prefer-global/url.js
+++ b/tests/lib/rules/prefer-global/url.js
@@ -26,6 +26,10 @@ new RuleTester({
             code: "var { URL } = require('url'); var b = new URL(s)",
             options: ["never"],
         },
+        {
+            code: "var { URL } = require('node:url'); var b = new URL(s)",
+            options: ["never"],
+        },
     ],
     invalid: [
         {
@@ -33,7 +37,16 @@ new RuleTester({
             errors: [{ messageId: "preferGlobal" }],
         },
         {
+            code: "var { URL } = require('node:url'); var b = new URL(s)",
+            errors: [{ messageId: "preferGlobal" }],
+        },
+        {
             code: "var { URL } = require('url'); var b = new URL(s)",
+            options: ["always"],
+            errors: [{ messageId: "preferGlobal" }],
+        },
+        {
+            code: "var { URL } = require('node:url'); var b = new URL(s)",
             options: ["always"],
             errors: [{ messageId: "preferGlobal" }],
         },


### PR DESCRIPTION
Example problem:

```ts
/* "n/prefer-global/buffer": "error" */

require('buffer').Buffer; // <- error
require('node:buffer').Buffer; // <- no error
```

This PR will allow for every `prefer-global` rule to check their module's `node:` counterparts.