### PR TITLE
fix: modules support range

### DIFF
--- a/lib/rules/no-unsupported-features/es-syntax.js
+++ b/lib/rules/no-unsupported-features/es-syntax.js
@@ -126,7 +126,7 @@ const features = {
         ruleId: "no-modules",
         cases: [
             {
-                supported: "13.2.0",
+                supported: new Range("^12.17 || >=13.2"),
                 messageId: "no-modules",
             },
         ],
@@ -379,7 +379,7 @@ const features = {
         ruleId: "no-dynamic-import",
         cases: [
             {
-                supported: new Range(">=12.17 <13 || >=13.2"),
+                supported: new Range("^12.17 || >=13.2"),
                 messageId: "no-dynamic-import",
             },
         ],


### PR DESCRIPTION
- Modules is available from v12.17

<img width="928" alt="Screen Shot 2022-11-25 at 2 02 06 PM" src="https://user-images.githubusercontent.com/1075694/203904825-86827bee-6cee-417d-863d-8a5fb4e7e220.png">

- Refactored `>=12.17 <13` to `^12.17`, which is the same thing but more readable