### PR TITLE
chore: update eslint-doc-generator to v1.0.0

### DIFF
--- a/docs/rules/no-unsupported-features.md
+++ b/docs/rules/no-unsupported-features.md
@@ -1,6 +1,6 @@
 # Disallow unsupported ECMAScript features on the specified version (`n/no-unsupported-features`)
 
-❌ This rule is deprecated. It was replaced by [`no-unsupported-features/es-syntax`](no-unsupported-features/es-syntax.md), [`no-unsupported-features/es-builtins`](no-unsupported-features/es-builtins.md).
+❌ This rule is deprecated. It was replaced by [`n/no-unsupported-features/es-syntax`](../../docs/rules/no-unsupported-features/es-syntax.md),[`n/no-unsupported-features/es-builtins`](../../docs/rules/no-unsupported-features/es-builtins.md).
 
 <!-- end auto-generated rule header -->
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "esbuild": "^0.14.39",
         "eslint": "^8.27.0",
         "eslint-config-prettier": "^8.5.0",
-        "eslint-doc-generator": "^0.19.1",
+        "eslint-doc-generator": "^1.0.0",
         "eslint-plugin-eslint-plugin": "^5.0.6",
         "eslint-plugin-n": "file:.",
         "fast-glob": "^3.2.12",
@@ -63,7 +63,7 @@
         "test": "nyc npm run -s test:_mocha",
         "test:_mocha": "_mocha \"tests/lib/**/*.js\" --reporter progress --timeout 4000",
         "test:ci": "nyc npm run -s test:_mocha",
-        "update:eslint-docs": "eslint-doc-generator --config-emoji recommended-module,☑️ --config-emoji recommended-script,✔️ --split-by meta.docs.category --ignore-config recommended-module --ignore-config recommended-script --url-configs \"https://github.com/eslint-community/eslint-plugin-n#-configs\"",
+        "update:eslint-docs": "eslint-doc-generator --config-emoji recommended-module,☑️ --config-emoji recommended-script,✔️ --rule-list-split meta.docs.category --ignore-config recommended-module --ignore-config recommended-script --url-configs \"https://github.com/eslint-community/eslint-plugin-n#-configs\"",
         "version": "npm run -s build && eslint lib/rules --fix && git add .",
         "watch": "npm run test:_mocha -- --watch --growl"
     },


### PR DESCRIPTION
First stable [v1.0.0](https://github.com/bmish/eslint-doc-generator/releases/tag/v1.0.0) release of [eslint-doc-generator](https://github.com/bmish/eslint-doc-generator).

Originally added in:
* https://github.com/eslint-community/eslint-plugin-n/pull/61