### PR TITLE
Allow imports of self-referenced package

### DIFF
--- a/lib/util/check-extraneous.js
+++ b/lib/util/check-extraneous.js
@@ -25,7 +25,7 @@ exports.checkExtraneous = function checkExtraneous(context, filePath, targets) {
 
     const allowed = new Set(getAllowModules(context))
     const dependencies = new Set(
-        [].concat(
+        [packageInfo.name].concat(
             Object.keys(packageInfo.dependencies || {}),
             Object.keys(packageInfo.devDependencies || {}),
             Object.keys(packageInfo.peerDependencies || {}),


### PR DESCRIPTION
You can import a package itself by self-referencing it with the package name, instead of needing to use relative paths.