### PR TITLE
feat!: engines.node defaults to 16.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The rules get the supported Node.js version range from the following, falling ba
 3. `package.json` [`engines`] field
 4. `>=16.0.0`
 
-If you omit the [engines] field, this rule chooses `>=16.0.0` as the configured Node.js version since `16` is the active lts (see also [Node.js Release Working Group](https://github.com/nodejs/Release#readme)).
+If you omit the [engines] field, this rule chooses `>=16.0.0` as the configured Node.js version since `16` is the maintained lts (see also [Node.js Release Working Group](https://github.com/nodejs/Release#readme)).
 
 For Node.js packages, using the [`engines`] field is recommended because it's the official way to indicate support:
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ npm install --save-dev eslint eslint-plugin-n
 - Requires Node.js `>=16.0.0`
 - Requires ESLint `>=7.0.0`
 
-**Note:** It recommends a use of [the "engines" field of package.json](https://docs.npmjs.com/files/package.json#engines). The "engines" field is used by `n/no-unsupported-features/*` rules.
-
 **.eslintrc.json** (An example)
 
 ```jsonc
@@ -52,6 +50,31 @@ npm install --save-dev eslint eslint-plugin-n
     }
 }
 ```
+
+### Configured Node.js version range
+
+The rules get the supported Node.js version range from the following, falling back to the next if unspecified:
+
+1. Rule configuration `version`
+2. ESLint [shared setting](http://eslint.org/docs/user-guide/configuring.html#adding-shared-settings) `node.version`
+3. `package.json` [`engines`] field
+4. `>=16.0.0`
+
+If you omit the [engines] field, this rule chooses `>=16.0.0` as the configured Node.js version since `16` is the active lts (see also [Node.js Release Working Group](https://github.com/nodejs/Release#readme)).
+
+For Node.js packages, using the [`engines`] field is recommended because it's the official way to indicate support:
+
+```json
+{
+    "name": "your-module",
+    "version": "1.0.0",
+    "engines": {
+        "node": ">=16.0.0"
+    }
+}
+```
+
+For [Shareable Configs](https://eslint.org/docs/latest/developer-guide/shareable-configs) or packages with a different development environment (e.g. pre-compiled, web package, etc.), you can configure ESLint with `settings.node.version` to specify support.
 
 ## 📖 Rules
 

--- a/docs/rules/no-deprecated-api.md
+++ b/docs/rules/no-deprecated-api.md
@@ -151,12 +151,12 @@ For example of `package.json`:
     "name": "your-module",
     "version": "1.0.0",
     "engines": {
-        "node": ">=8.0.0"
+        "node": ">=16.0.0"
     }
 }
 ```
 
-If you omit the [engines] field, this rule chooses `>=8.0.0` as the configured Node.js version since `8` is the minimum version the community is maintaining (see also [Node.js Release Working Group](https://github.com/nodejs/Release#readme)).
+If you omit the [engines] field, this rule chooses `>=16.0.0` as the configured Node.js version since `16` is the active lts (see also [Node.js Release Working Group](https://github.com/nodejs/Release#readme)).
 
 ### Options
 
@@ -166,7 +166,7 @@ This rule has 4 options.
 {
     "rules": {
         "n/no-deprecated-api": ["error", {
-            "version": ">=8.0.0",
+            "version": ">=16.0.0",
             "ignoreModuleItems": [],
             "ignoreGlobalItems": []
             "ignoreIndirectDependencies": true

--- a/docs/rules/no-deprecated-api.md
+++ b/docs/rules/no-deprecated-api.md
@@ -141,22 +141,7 @@ This rule reports the following deprecated API.
 
 ### Configured Node.js version range
 
-This rule reads the [engines] field of `package.json` to detect which Node.js versions your module is supporting.
-
-I recommend the use of the [engines] field because it's the official way that indicates which Node.js versions your module is supporting.
-For example of `package.json`:
-
-```json
-{
-    "name": "your-module",
-    "version": "1.0.0",
-    "engines": {
-        "node": ">=16.0.0"
-    }
-}
-```
-
-If you omit the [engines] field, this rule chooses `>=16.0.0` as the configured Node.js version since `16` is the active lts (see also [Node.js Release Working Group](https://github.com/nodejs/Release#readme)).
+[Configured Node.js version range](../../README.md#configured-nodejs-version-range)
 
 ### Options
 

--- a/docs/rules/no-unsupported-features/es-builtins.md
+++ b/docs/rules/no-unsupported-features/es-builtins.md
@@ -19,28 +19,7 @@ See also [TC39 finished proposals](https://github.com/tc39/proposals/blob/master
 
 ### Configured Node.js version range
 
-This rule gets the supported Node.js version range from the following, falling back to the next if unspecified:
-
-1. Rule configuration `version`
-2. ESLint [shared setting](http://eslint.org/docs/user-guide/configuring.html#adding-shared-settings) `node.version`
-3. `package.json` [`engines`] field
-4. `>=16.0.0`
-
-If you omit the [engines] field, this rule chooses `>=16.0.0` as the configured Node.js version since `16` is the active lts (see also [Node.js Release Working Group](https://github.com/nodejs/Release#readme)).
-
-For Node.js packages, using the [`engines`] field is recommended because it's the official way to indicate support:
-
-```json
-{
-    "name": "your-module",
-    "version": "1.0.0",
-    "engines": {
-        "node": ">=16.0.0"
-    }
-}
-```
-
-For [Shareable Configs](https://eslint.org/docs/latest/developer-guide/shareable-configs) or packages with a different development environment (e.g. pre-compiled, web package, etc.), you can configure ESLint with `settings.node.version` to specify support.
+[Configured Node.js version range](../../../README.md#configured-nodejs-version-range)
 
 ### Options
 

--- a/docs/rules/no-unsupported-features/es-builtins.md
+++ b/docs/rules/no-unsupported-features/es-builtins.md
@@ -24,9 +24,9 @@ This rule gets the supported Node.js version range from the following, falling b
 1. Rule configuration `version`
 2. ESLint [shared setting](http://eslint.org/docs/user-guide/configuring.html#adding-shared-settings) `node.version`
 3. `package.json` [`engines`] field
-4. `>=8.0.0`
+4. `>=16.0.0`
 
-The default version is `8.0.0` because it's the minimum version the community is maintaining (see also [Node.js Release Working Group](https://github.com/nodejs/Release#readme)).
+If you omit the [engines] field, this rule chooses `>=16.0.0` as the configured Node.js version since `16` is the active lts (see also [Node.js Release Working Group](https://github.com/nodejs/Release#readme)).
 
 For Node.js packages, using the [`engines`] field is recommended because it's the official way to indicate support:
 
@@ -35,7 +35,7 @@ For Node.js packages, using the [`engines`] field is recommended because it's th
     "name": "your-module",
     "version": "1.0.0",
     "engines": {
-        "node": ">=8.0.0"
+        "node": ">=16.0.0"
     }
 }
 ```
@@ -47,7 +47,7 @@ For [Shareable Configs](https://eslint.org/docs/latest/developer-guide/shareable
 ```json
 {
     "n/no-unsupported-features/es-builtins": ["error", {
-        "version": ">=8.0.0",
+        "version": ">=16.0.0",
         "ignores": []
     }]
 }
@@ -159,7 +159,7 @@ For Example:
 {
     "settings": {
         "node": {
-            "version": ">=8.0.0",
+            "version": ">=16.0.0",
         }
     },
     "rules": {

--- a/docs/rules/no-unsupported-features/es-syntax.md
+++ b/docs/rules/no-unsupported-features/es-syntax.md
@@ -27,9 +27,9 @@ This rule gets the supported Node.js version range from the following, falling b
 1. Rule configuration `version`
 2. ESLint [shared setting](http://eslint.org/docs/user-guide/configuring.html#adding-shared-settings) `node.version`
 3. `package.json` [`engines`] field
-4. `>=8.0.0`
+4. `>=16.0.0`
 
-The default version is `8.0.0` because it's the minimum version the community is maintaining (see also [Node.js Release Working Group](https://github.com/nodejs/Release#readme)).
+If you omit the [engines] field, this rule chooses `>=16.0.0` as the configured Node.js version since `16` is the active lts (see also [Node.js Release Working Group](https://github.com/nodejs/Release#readme)).
 
 For Node.js packages, using the [`engines`] field is recommended because it's the official way to indicate support:
 
@@ -38,7 +38,7 @@ For Node.js packages, using the [`engines`] field is recommended because it's th
     "name": "your-module",
     "version": "1.0.0",
     "engines": {
-        "node": ">=8.0.0"
+        "node": ">=16.0.0"
     }
 }
 ```
@@ -50,7 +50,7 @@ For [Shareable Configs](https://eslint.org/docs/latest/developer-guide/shareable
 ```json
 {
     "n/no-unsupported-features/es-syntax": ["error", {
-        "version": ">=8.0.0",
+        "version": ">=16.0.0",
         "ignores": []
     }]
 }
@@ -144,7 +144,7 @@ For Example:
 {
     "settings": {
         "node": {
-            "version": ">=8.0.0",
+            "version": ">=16.0.0",
         }
     },
     "rules": {

--- a/docs/rules/no-unsupported-features/es-syntax.md
+++ b/docs/rules/no-unsupported-features/es-syntax.md
@@ -22,28 +22,7 @@ For example, set `2020` to `parserOptions.ecmaVersion`.
 
 ### Configured Node.js version range
 
-This rule gets the supported Node.js version range from the following, falling back to the next if unspecified:
-
-1. Rule configuration `version`
-2. ESLint [shared setting](http://eslint.org/docs/user-guide/configuring.html#adding-shared-settings) `node.version`
-3. `package.json` [`engines`] field
-4. `>=16.0.0`
-
-If you omit the [engines] field, this rule chooses `>=16.0.0` as the configured Node.js version since `16` is the active lts (see also [Node.js Release Working Group](https://github.com/nodejs/Release#readme)).
-
-For Node.js packages, using the [`engines`] field is recommended because it's the official way to indicate support:
-
-```json
-{
-    "name": "your-module",
-    "version": "1.0.0",
-    "engines": {
-        "node": ">=16.0.0"
-    }
-}
-```
-
-For [Shareable Configs](https://eslint.org/docs/latest/developer-guide/shareable-configs) or packages with a different development environment (e.g. pre-compiled, web package, etc.), you can configure ESLint with `settings.node.version` to specify support.
+[Configured Node.js version range](../../../README.md#configured-nodejs-version-range)
 
 ### Options
 

--- a/docs/rules/no-unsupported-features/node-builtins.md
+++ b/docs/rules/no-unsupported-features/node-builtins.md
@@ -16,28 +16,7 @@ This rule reports APIs of Node.js built-in APIs on the basis of [Node.js v13.2.0
 
 ### Configured Node.js version range
 
-This rule gets the supported Node.js version range from the following, falling back to the next if unspecified:
-
-1. Rule configuration `version`
-2. ESLint [shared setting](http://eslint.org/docs/user-guide/configuring.html#adding-shared-settings) `node.version`
-3. `package.json` [`engines`] field
-4. `>=16.0.0`
-
-If you omit the [engines] field, this rule chooses `>=16.0.0` as the configured Node.js version since `16` is the active lts (see also [Node.js Release Working Group](https://github.com/nodejs/Release#readme)).
-
-For Node.js packages, using the [`engines`] field is recommended because it's the official way to indicate support:
-
-```json
-{
-    "name": "your-module",
-    "version": "1.0.0",
-    "engines": {
-        "node": ">=16.0.0"
-    }
-}
-```
-
-For [Shareable Configs](https://eslint.org/docs/latest/developer-guide/shareable-configs) or packages with a different development environment (e.g. pre-compiled, web package, etc.), you can configure ESLint with `settings.node.version` to specify support.
+[Configured Node.js version range](../../../README.md#configured-nodejs-version-range)
 
 ### Options
 

--- a/docs/rules/no-unsupported-features/node-builtins.md
+++ b/docs/rules/no-unsupported-features/node-builtins.md
@@ -21,9 +21,9 @@ This rule gets the supported Node.js version range from the following, falling b
 1. Rule configuration `version`
 2. ESLint [shared setting](http://eslint.org/docs/user-guide/configuring.html#adding-shared-settings) `node.version`
 3. `package.json` [`engines`] field
-4. `>=8.0.0`
+4. `>=16.0.0`
 
-The default version is `8.0.0` because it's the minimum version the community is maintaining (see also [Node.js Release Working Group](https://github.com/nodejs/Release#readme)).
+If you omit the [engines] field, this rule chooses `>=16.0.0` as the configured Node.js version since `16` is the active lts (see also [Node.js Release Working Group](https://github.com/nodejs/Release#readme)).
 
 For Node.js packages, using the [`engines`] field is recommended because it's the official way to indicate support:
 
@@ -32,7 +32,7 @@ For Node.js packages, using the [`engines`] field is recommended because it's th
     "name": "your-module",
     "version": "1.0.0",
     "engines": {
-        "node": ">=8.0.0"
+        "node": ">=16.0.0"
     }
 }
 ```
@@ -44,7 +44,7 @@ For [Shareable Configs](https://eslint.org/docs/latest/developer-guide/shareable
 ```json
 {
     "n/no-unsupported-features/node-builtins": ["error", {
-        "version": ">=8.0.0",
+        "version": ">=16.0.0",
         "ignores": []
     }]
 }
@@ -343,7 +343,7 @@ For Example:
 {
     "settings": {
         "node": {
-            "version": ">=8.0.0",
+            "version": ">=16.0.0",
         }
     },
     "rules": {

--- a/lib/util/get-configured-node-version.js
+++ b/lib/util/get-configured-node-version.js
@@ -36,7 +36,7 @@ function getEnginesNode(filename) {
  *
  * 1. Parse a given version then return it if it's valid.
  * 2. Look package.json up and parse `engines.node` then return it if it's valid.
- * 3. Return `>=8.0.0`.
+ * 3. Return `>=16.0.0`.
  *
  * @param {string|undefined} version The version range text.
  * @param {string} filename The path to the current linting file.
@@ -52,7 +52,7 @@ module.exports = function getConfiguredNodeVersion(context) {
     return (
         getSemverRange(version) ||
         getEnginesNode(filePath) ||
-        getSemverRange(">=8.0.0")
+        getSemverRange(">=16.0.0")
     )
 }
 

--- a/tests/lib/rules/no-unsupported-features/es-syntax.js
+++ b/tests/lib/rules/no-unsupported-features/es-syntax.js
@@ -2663,6 +2663,7 @@ ruleTester.run(
                 {
                     filename: fixture("invalid/a.js"),
                     code: "var a = { ...obj }",
+                    options: [{version: '>=8.0.0'}],
                     errors: [
                         {
                             messageId: "no-rest-spread-properties",
@@ -2683,6 +2684,7 @@ ruleTester.run(
                 {
                     filename: fixture("nothing/a.js"),
                     code: "var a = { ...obj }",
+                    options: [{version: '>=8.0.0'}],
                     errors: [
                         {
                             messageId: "no-rest-spread-properties",


### PR DESCRIPTION
node.js < 13, v15 has been eol.
and node.js v14 will be eol in a few months.

refs: #42


TODO:

- [x] docs needs to be updated.