### PR TITLE
feat!: update default `ecmaVersion` to 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ npm install --save-dev eslint eslint-plugin-n
 {
     "extends": ["eslint:recommended", "plugin:n/recommended"],
     "parserOptions": {
-        // Only ESLint 6.2.0 and later support ES2020.
-        "ecmaVersion": 2020
+        "ecmaVersion": 2021
     },
     "rules": {
         "n/exports-style": ["error", "module.exports"],
@@ -155,7 +154,7 @@ These preset configs:
 
 - enable [no-process-exit](http://eslint.org/docs/rules/no-process-exit) rule because [the official document](https://nodejs.org/api/process.html#process_process_exit_code) does not recommend a use of `process.exit()`.
 - enable plugin rules which are given ✅ in the above table.
-- add `{ecmaVersion: 2019}` and etc into `parserOptions`.
+- add `{ecmaVersion: 2021}` and etc into `parserOptions`.
 - add proper globals into `globals`.
 - add this plugin into `plugins`.
 

--- a/lib/configs/recommended-module.js
+++ b/lib/configs/recommended-module.js
@@ -13,7 +13,7 @@ module.exports = {
     },
     parserOptions: {
         ecmaFeatures: { globalReturn: false },
-        ecmaVersion: 2019,
+        ecmaVersion: 2021,
         sourceType: "module",
     },
     plugins: ["n"],

--- a/lib/configs/recommended-script.js
+++ b/lib/configs/recommended-script.js
@@ -13,7 +13,7 @@ module.exports = {
     },
     parserOptions: {
         ecmaFeatures: { globalReturn: true },
-        ecmaVersion: 2019,
+        ecmaVersion: 2021,
         sourceType: "script",
     },
     plugins: ["n"],


### PR DESCRIPTION
according to node.green, Node.js 16.0.0 supports all ES2021 features.

refs: https://github.com/eslint-community/eslint-plugin-n/issues/42