### PR TITLE
avoid logical nullish assignment to allow node < v15 support

### DIFF
--- a/lib/util/get-typescript-extension-map.js
+++ b/lib/util/get-typescript-extension-map.js
@@ -40,7 +40,9 @@ function normalise(typescriptExtensionMap) {
         if (!typescript) {
             continue
         }
-        backward[javascript] ??= []
+        if (backward['javascript'] === null || backward['javascript'] === undefined) {
+            backward['javascript'] = [];
+        }
         backward[javascript].push(typescript)
     }
     return { forward, backward }


### PR DESCRIPTION
fixes this error:
```
[04:42:31.066] Oops! Something went wrong! :(
[04:42:31.066] 
[04:42:31.066] ESLint: 8.33.0
[04:42:31.066] 
[04:42:31.066] /home/builduser/work/a5af963239e640d2/packages/package/node_modules/eslint-plugin-n/lib/util/get-typescript-extension-map.js:43
[04:42:31.066]         backward[javascript] ??= []
[04:42:31.066]                              ^^^
[04:42:31.066] 
[04:42:31.066] SyntaxError: Unexpected token '??='
```