### PR TITLE
fix: Normalise `package.json#files` before checking ignores and whitelist

### DIFF
--- a/lib/util/get-npmignore.js
+++ b/lib/util/get-npmignore.js
@@ -12,7 +12,6 @@ const exists = require("./exists")
 const getPackageJson = require("./get-package-json")
 
 const cache = new Cache()
-const SLASH_AT_BEGIN_AND_END = /^!?\/+|^!|\/+$/gu
 const PARENT_RELATIVE_PATH = /^\.\./u
 const NEVER_IGNORED =
     /^(?:readme\.[^.]*|(?:licen[cs]e|changes|changelog|history)(?:\.[^.]*)?)$/iu
@@ -90,7 +89,10 @@ function parseWhiteList(files) {
 
     for (const file of files) {
         if (typeof file === "string" && file) {
-            const body = file.replace(SLASH_AT_BEGIN_AND_END, "")
+            const body = path
+                .normalize(file.replace(/^!/u, ""))
+                .replace(/\/+$/u, "")
+
             if (file.startsWith("!")) {
                 igN.add(`${body}`)
                 igN.add(`${body}/**`)

--- a/lib/util/get-npmignore.js
+++ b/lib/util/get-npmignore.js
@@ -89,7 +89,7 @@ function parseWhiteList(files) {
 
     for (const file of files) {
         if (typeof file === "string" && file) {
-            const body = path
+            const body = path.posix
                 .normalize(file.replace(/^!/u, ""))
                 .replace(/\/+$/u, "")
 

--- a/tests/fixtures/no-unpublished/issue99/bin.js
+++ b/tests/fixtures/no-unpublished/issue99/bin.js
@@ -1,0 +1,1 @@
+#!/usr/bin/env node

--- a/tests/fixtures/no-unpublished/issue99/package.json
+++ b/tests/fixtures/no-unpublished/issue99/package.json
@@ -1,0 +1,8 @@
+{
+    "bin": "./bin.js",
+    "exports": "./index.js",
+    "files": [
+        "./index.js",
+        "bin.js"
+    ]
+}

--- a/tests/lib/rules/no-unpublished-require.js
+++ b/tests/lib/rules/no-unpublished-require.js
@@ -240,6 +240,18 @@ ruleTester.run("no-unpublished-require", rule, {
             env: { node: true },
         },
 
+        // Allow files to start with './' in package.json#files
+        {
+            filename: fixture("issue99/test/bin.js"),
+            code: "require('./index.js');",
+            env: { node: true },
+        },
+        {
+            filename: fixture("issue99/test/bin.js"),
+            code: "require('.');",
+            env: { node: true },
+        },
+
         // allowModules option
         {
             filename: fixture("1/test.js"),

--- a/tests/lib/rules/no-unpublished-require.js
+++ b/tests/lib/rules/no-unpublished-require.js
@@ -240,6 +240,7 @@ ruleTester.run("no-unpublished-require", rule, {
             env: { node: true },
         },
 
+        // https://github.com/eslint-community/eslint-plugin-n/issues/122
         // Allow files to start with './' in package.json#files
         {
             filename: fixture("issue99/test/bin.js"),


### PR DESCRIPTION
This normalises paths in `package.json#files` before we check to see if the file will be published to npm.

Context can be found in https://github.com/eslint-community/eslint-plugin-n/issues/122#issuecomment-1737693426