### PR TITLE
chore: use maintained `npm-run-all` fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "lint-staged": "^13.2.2",
         "markdownlint-cli": "^0.35.0",
         "mocha": "^10.2.0",
-        "npm-run-all": "^4.1.5",
+        "npm-run-all2": "^6.1.1",
         "nyc": "^15.1.0",
         "opener": "^1.5.2",
         "prettier": "^2.8.8",


### PR DESCRIPTION
@bcomnes and I maintain a fork of the `npm-run-all` package that's also one of the many mysticatea packages out there.

Here's a PR that moves this module to make use of that up to date fork.