### PR TITLE
docs: fix repository URL:s, tweak badges + remove old non-working `codecov`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,7 +61,3 @@ jobs:
           npm install --no-save eslint@${{ matrix.eslint }}
       - name: Test
         run: npm run -s test:ci
-      - name: Send Coverage
-        run: npm run -s codecov
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 > forked from [eslint-plugin-node](https://www.npmjs.com/package/eslint-plugin-node) v11.1.0. as the original repository seems [no longer maintained](https://github.com/mysticatea/eslint-plugin-node/issues/300).
 
-[![npm version](https://img.shields.io/npm/v/eslint-plugin-n.svg)](https://www.npmjs.com/package/eslint-plugin-n) [![Downloads/month](https://img.shields.io/npm/dm/eslint-plugin-n.svg)](http://www.npmtrends.com/eslint-plugin-n) [![Build Status](https://github.com/weiran-zsd/eslint-plugin-node/workflows/CI/badge.svg)](https://github.com/weiran-zsd/eslint-plugin-node/actions) [![Coverage Status](https://codecov.io/gh/weiran-zsd/eslint-plugin-node/branch/master/graph/badge.svg)](https://codecov.io/gh/weiran-zsd/eslint-plugin-node) [![Dependency Status](https://david-dm.org/weiran-zsd/eslint-plugin-node.svg)](https://david-dm.org/weiran-zsd/eslint-plugin-node)
+[![npm version](https://img.shields.io/npm/v/eslint-plugin-n.svg)](https://www.npmjs.com/package/eslint-plugin-n)
+[![Downloads](https://img.shields.io/npm/dm/eslint-plugin-n.svg)](https://www.npmjs.com/package/eslint-plugin-n)
+[![Build Status](https://github.com/eslint-community/eslint-plugin-n/workflows/CI/badge.svg)](https://github.com/eslint-community/eslint-plugin-n/actions)
 
 Additional ESLint's rules for Node.js
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Deprecated rules follow ESLint's [deprecation policy](https://eslint.org/docs/us
 
 ## 📰 Changelog
 
-- [GitHub Releases](https://github.com/weiran-zsd/eslint-plugin-node/releases)
+- [GitHub Releases](https://github.com/eslint-community/eslint-plugin-n/releases)
 
 ## ❤️ Contributing
 

--- a/lib/rules/callback-return.js
+++ b/lib/rules/callback-return.js
@@ -11,7 +11,7 @@ module.exports = {
             description: "require `return` statements after callbacks",
             category: "Stylistic Issues",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/callback-return.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/callback-return.md",
         },
         schema: [
             {

--- a/lib/rules/exports-style.js
+++ b/lib/rules/exports-style.js
@@ -229,7 +229,7 @@ module.exports = {
             description: "enforce either `module.exports` or `exports`",
             category: "Stylistic Issues",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/exports-style.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/exports-style.md",
         },
         type: "suggestion",
         fixable: "code",

--- a/lib/rules/file-extension-in-import.js
+++ b/lib/rules/file-extension-in-import.js
@@ -39,7 +39,7 @@ module.exports = {
                 "enforce the style of file extensions in `import` declarations",
             category: "Stylistic Issues",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/file-extension-in-import.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/file-extension-in-import.md",
         },
         fixable: "code",
         messages: {

--- a/lib/rules/global-require.js
+++ b/lib/rules/global-require.js
@@ -55,7 +55,7 @@ module.exports = {
                 "require `require()` calls to be placed at top-level module scope",
             category: "Stylistic Issues",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/global-require.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/global-require.md",
         },
         fixable: null,
         schema: [],

--- a/lib/rules/handle-callback-err.js
+++ b/lib/rules/handle-callback-err.js
@@ -11,7 +11,7 @@ module.exports = {
             description: "require error handling in callbacks",
             category: "Possible Errors",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/handle-callback-err.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/handle-callback-err.md",
         },
         fixable: null,
         schema: [

--- a/lib/rules/no-callback-literal.js
+++ b/lib/rules/no-callback-literal.js
@@ -11,7 +11,7 @@ module.exports = {
                 "enforce Node.js-style error-first callback pattern is followed",
             category: "Possible Errors",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-callback-literal.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-callback-literal.md",
         },
         type: "problem",
         fixable: null,

--- a/lib/rules/no-deprecated-api.js
+++ b/lib/rules/no-deprecated-api.js
@@ -693,7 +693,7 @@ module.exports = {
             description: "disallow deprecated APIs",
             category: "Best Practices",
             recommended: true,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-deprecated-api.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-deprecated-api.md",
         },
         type: "problem",
         fixable: null,

--- a/lib/rules/no-exports-assign.js
+++ b/lib/rules/no-exports-assign.js
@@ -40,7 +40,7 @@ module.exports = {
             description: "disallow the assignment to `exports`",
             category: "Possible Errors",
             recommended: true,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-exports-assign.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-exports-assign.md",
         },
         fixable: null,
         messages: {

--- a/lib/rules/no-extraneous-import.js
+++ b/lib/rules/no-extraneous-import.js
@@ -17,7 +17,7 @@ module.exports = {
                 "disallow `import` declarations which import extraneous modules",
             category: "Possible Errors",
             recommended: true,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-extraneous-import.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-extraneous-import.md",
         },
         type: "problem",
         fixable: null,

--- a/lib/rules/no-extraneous-require.js
+++ b/lib/rules/no-extraneous-require.js
@@ -18,7 +18,7 @@ module.exports = {
                 "disallow `require()` expressions which import extraneous modules",
             category: "Possible Errors",
             recommended: true,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-extraneous-require.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-extraneous-require.md",
         },
         type: "problem",
         fixable: null,

--- a/lib/rules/no-hide-core-modules.js
+++ b/lib/rules/no-hide-core-modules.js
@@ -59,7 +59,7 @@ module.exports = {
                 "disallow third-party modules which are hiding core modules",
             category: "Possible Errors",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-hide-core-modules.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-hide-core-modules.md",
         },
         type: "problem",
         deprecated: true,
@@ -81,8 +81,9 @@ module.exports = {
             },
         ],
         messages: {
-            "unexpectedImport": "Unexpected import of third-party module '{{name}}'.",
-        }
+            unexpectedImport:
+                "Unexpected import of third-party module '{{name}}'.",
+        },
     },
     create(context) {
         if (context.getFilename() === "<input>") {

--- a/lib/rules/no-missing-import.js
+++ b/lib/rules/no-missing-import.js
@@ -18,7 +18,7 @@ module.exports = {
                 "disallow `import` declarations which import non-existence modules",
             category: "Possible Errors",
             recommended: true,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-missing-import.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-missing-import.md",
         },
         type: "problem",
         fixable: null,

--- a/lib/rules/no-missing-require.js
+++ b/lib/rules/no-missing-require.js
@@ -19,7 +19,7 @@ module.exports = {
                 "disallow `require()` expressions which import non-existence modules",
             category: "Possible Errors",
             recommended: true,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-missing-require.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-missing-require.md",
         },
         type: "problem",
         fixable: null,

--- a/lib/rules/no-mixed-requires.js
+++ b/lib/rules/no-mixed-requires.js
@@ -73,7 +73,7 @@ module.exports = {
                 "disallow `require` calls to be mixed with regular variable declarations",
             category: "Stylistic Issues",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-mixed-requires.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-mixed-requires.md",
         },
         fixable: null,
         schema: [

--- a/lib/rules/no-new-require.js
+++ b/lib/rules/no-new-require.js
@@ -11,7 +11,7 @@ module.exports = {
             description: "disallow `new` operators with calls to `require`",
             category: "Possible Errors",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-new-require.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-new-require.md",
         },
         fixable: null,
         schema: [],

--- a/lib/rules/no-path-concat.js
+++ b/lib/rules/no-path-concat.js
@@ -168,7 +168,7 @@ module.exports = {
                 "disallow string concatenation with `__dirname` and `__filename`",
             category: "Possible Errors",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-path-concat.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-path-concat.md",
         },
         fixable: null,
         schema: [],

--- a/lib/rules/no-process-env.js
+++ b/lib/rules/no-process-env.js
@@ -15,7 +15,7 @@ module.exports = {
             description: "disallow the use of `process.env`",
             category: "Stylistic Issues",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-process-env.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-process-env.md",
         },
         fixable: null,
         schema: [],

--- a/lib/rules/no-process-exit.js
+++ b/lib/rules/no-process-exit.js
@@ -11,7 +11,7 @@ module.exports = {
             description: "disallow the use of `process.exit()`",
             category: "Possible Errors",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-process-exit.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-process-exit.md",
         },
         fixable: null,
         schema: [],

--- a/lib/rules/no-restricted-import.js
+++ b/lib/rules/no-restricted-import.js
@@ -15,7 +15,7 @@ module.exports = {
                 "disallow specified modules when loaded by `import` declarations",
             category: "Stylistic Issues",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-restricted-import.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-restricted-import.md",
         },
         fixable: null,
         schema: [

--- a/lib/rules/no-restricted-require.js
+++ b/lib/rules/no-restricted-require.js
@@ -15,7 +15,7 @@ module.exports = {
             description: "disallow specified modules when loaded by `require`",
             category: "Stylistic Issues",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-restricted-require.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-restricted-require.md",
         },
         fixable: null,
         schema: [

--- a/lib/rules/no-sync.js
+++ b/lib/rules/no-sync.js
@@ -11,7 +11,7 @@ module.exports = {
             description: "disallow synchronous methods",
             category: "Stylistic Issues",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-sync.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-sync.md",
         },
         fixable: null,
         schema: [

--- a/lib/rules/no-unpublished-bin.js
+++ b/lib/rules/no-unpublished-bin.js
@@ -35,7 +35,7 @@ module.exports = {
             description: "disallow `bin` files that npm ignores",
             category: "Possible Errors",
             recommended: true,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-unpublished-bin.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unpublished-bin.md",
         },
         type: "problem",
         fixable: null,
@@ -49,8 +49,9 @@ module.exports = {
             },
         ],
         messages: {
-            invalidIgnored: "npm ignores '{{name}}'. Check 'files' field of 'package.json' or '.npmignore'."
-        }
+            invalidIgnored:
+                "npm ignores '{{name}}'. Check 'files' field of 'package.json' or '.npmignore'.",
+        },
     },
     create(context) {
         return {

--- a/lib/rules/no-unpublished-import.js
+++ b/lib/rules/no-unpublished-import.js
@@ -17,7 +17,7 @@ module.exports = {
                 "disallow `import` declarations which import private modules",
             category: "Possible Errors",
             recommended: true,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-unpublished-import.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unpublished-import.md",
         },
         type: "problem",
         fixable: null,

--- a/lib/rules/no-unpublished-require.js
+++ b/lib/rules/no-unpublished-require.js
@@ -18,7 +18,7 @@ module.exports = {
                 "disallow `require()` expressions which import private modules",
             category: "Possible Errors",
             recommended: true,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-unpublished-require.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unpublished-require.md",
         },
         type: "problem",
         fixable: null,

--- a/lib/rules/no-unsupported-features.js
+++ b/lib/rules/no-unsupported-features.js
@@ -1051,7 +1051,7 @@ module.exports = {
             category: "Possible Errors",
             recommended: false,
 
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-unsupported-features.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unsupported-features.md",
         },
         type: "problem",
         deprecated: true,

--- a/lib/rules/no-unsupported-features/es-builtins.js
+++ b/lib/rules/no-unsupported-features/es-builtins.js
@@ -145,7 +145,7 @@ module.exports = {
                 "disallow unsupported ECMAScript built-ins on the specified version",
             category: "Possible Errors",
             recommended: true,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-unsupported-features/es-builtins.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unsupported-features/es-builtins.md",
         },
         type: "problem",
         fixable: null,

--- a/lib/rules/no-unsupported-features/es-syntax.js
+++ b/lib/rules/no-unsupported-features/es-syntax.js
@@ -525,7 +525,7 @@ module.exports = {
                 "disallow unsupported ECMAScript syntax on the specified version",
             category: "Possible Errors",
             recommended: true,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-unsupported-features/es-syntax.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unsupported-features/es-syntax.md",
         },
         type: "problem",
         fixable: null,

--- a/lib/rules/no-unsupported-features/node-builtins.js
+++ b/lib/rules/no-unsupported-features/node-builtins.js
@@ -381,7 +381,7 @@ module.exports = {
                 "disallow unsupported Node.js built-in APIs on the specified version",
             category: "Possible Errors",
             recommended: true,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-unsupported-features/node-builtins.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unsupported-features/node-builtins.md",
         },
         type: "problem",
         fixable: null,

--- a/lib/rules/prefer-global/buffer.js
+++ b/lib/rules/prefer-global/buffer.js
@@ -25,7 +25,7 @@ module.exports = {
                 'enforce either `Buffer` or `require("buffer").Buffer`',
             category: "Stylistic Issues",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/prefer-global/buffer.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global/buffer.md",
         },
         type: "suggestion",
         fixable: null,

--- a/lib/rules/prefer-global/console.js
+++ b/lib/rules/prefer-global/console.js
@@ -22,7 +22,7 @@ module.exports = {
             description: 'enforce either `console` or `require("console")`',
             category: "Stylistic Issues",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/prefer-global/console.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global/console.md",
         },
         type: "suggestion",
         fixable: null,

--- a/lib/rules/prefer-global/process.js
+++ b/lib/rules/prefer-global/process.js
@@ -22,7 +22,7 @@ module.exports = {
             description: 'enforce either `process` or `require("process")`',
             category: "Stylistic Issues",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/prefer-global/process.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global/process.md",
         },
         type: "suggestion",
         fixable: null,

--- a/lib/rules/prefer-global/text-decoder.js
+++ b/lib/rules/prefer-global/text-decoder.js
@@ -25,7 +25,7 @@ module.exports = {
                 'enforce either `TextDecoder` or `require("util").TextDecoder`',
             category: "Stylistic Issues",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/prefer-global/text-decoder.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global/text-decoder.md",
         },
         type: "suggestion",
         fixable: null,

--- a/lib/rules/prefer-global/text-encoder.js
+++ b/lib/rules/prefer-global/text-encoder.js
@@ -25,7 +25,7 @@ module.exports = {
                 'enforce either `TextEncoder` or `require("util").TextEncoder`',
             category: "Stylistic Issues",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/prefer-global/text-encoder.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global/text-encoder.md",
         },
         type: "suggestion",
         fixable: null,

--- a/lib/rules/prefer-global/url-search-params.js
+++ b/lib/rules/prefer-global/url-search-params.js
@@ -25,7 +25,7 @@ module.exports = {
                 'enforce either `URLSearchParams` or `require("url").URLSearchParams`',
             category: "Stylistic Issues",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/prefer-global/url-search-params.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global/url-search-params.md",
         },
         type: "suggestion",
         fixable: null,

--- a/lib/rules/prefer-global/url.js
+++ b/lib/rules/prefer-global/url.js
@@ -24,7 +24,7 @@ module.exports = {
             description: 'enforce either `URL` or `require("url").URL`',
             category: "Stylistic Issues",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/prefer-global/url.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global/url.md",
         },
         type: "suggestion",
         fixable: null,

--- a/lib/rules/prefer-promises/dns.js
+++ b/lib/rules/prefer-promises/dns.js
@@ -40,7 +40,7 @@ module.exports = {
             description: 'enforce `require("dns").promises`',
             category: "Stylistic Issues",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/prefer-promises/dns.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-promises/dns.md",
         },
         fixable: null,
         messages: {

--- a/lib/rules/prefer-promises/fs.js
+++ b/lib/rules/prefer-promises/fs.js
@@ -42,7 +42,7 @@ module.exports = {
             description: 'enforce `require("fs").promises`',
             category: "Stylistic Issues",
             recommended: false,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/prefer-promises/fs.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-promises/fs.md",
         },
         fixable: null,
         messages: {

--- a/lib/rules/process-exit-as-throw.js
+++ b/lib/rules/process-exit-as-throw.js
@@ -151,7 +151,7 @@ module.exports = {
                 "require that `process.exit()` expressions use the same code path as `throw`",
             category: "Possible Errors",
             recommended: true,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/process-exit-as-throw.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/process-exit-as-throw.md",
         },
         type: "problem",
         fixable: null,

--- a/lib/rules/shebang.js
+++ b/lib/rules/shebang.js
@@ -72,7 +72,7 @@ module.exports = {
             description: "require correct usage of shebang",
             category: "Possible Errors",
             recommended: true,
-            url: "https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/shebang.md",
+            url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/shebang.md",
         },
         type: "problem",
         fixable: "code",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
         "@eslint/js": "^8.43.0",
         "@types/eslint": "^8.44.2",
         "@typescript-eslint/parser": "^5.60.0",
-        "codecov": "^3.8.2",
         "esbuild": "^0.18.7",
         "eslint": "^8.43.0",
         "eslint-config-prettier": "^8.8.0",
@@ -54,7 +53,6 @@
     "scripts": {
         "build": "node scripts/update",
         "clean": "rimraf .nyc_output coverage",
-        "codecov": "nyc report --reporter text-lcov | codecov --pipe --disable=gcov -t $CODECOV_TOKEN",
         "coverage": "opener ./coverage/lcov-report/index.html",
         "format": "prettier --loglevel warn --write \"**/*.{js,css,md}\"",
         "lint": "npm-run-all \"lint:*\"",


### PR DESCRIPTION
There were still many `/weiran-zsd/` URL:s scattered around this project, I decided to make them all point to the proper repository URL.

While doing that I also cleaned up the badges and aligned them to a subset of the setup that `eslint/eslint` uses.

I also removed `codecov`, as this repo is missing the secret needed to upload the code coverage, so it has been failing for a long time + the actual `codecov` tool this repo uses is unmaintained and deprecated: https://about.codecov.io/blog/codecov-uploader-deprecation-plan/