### PR TITLE
feat: detect non-member expressions in n/no-sync

### DIFF
--- a/lib/rules/no-sync.js
+++ b/lib/rules/no-sync.js
@@ -4,6 +4,24 @@
  */
 "use strict"
 
+const allowedAtRootLevelSelector = [
+    // fs.readFileSync()
+    ":function MemberExpression > Identifier[name=/Sync$/]",
+    // readFileSync.call(null, 'path')
+    ":function MemberExpression > Identifier[name=/Sync$/]",
+    // readFileSync()
+    ":function :not(MemberExpression) > Identifier[name=/Sync$/]",
+]
+
+const disallowedAtRootLevelSelector = [
+    // fs.readFileSync()
+    "MemberExpression > Identifier[name=/Sync$/]",
+    // readFileSync.call(null, 'path')
+    "MemberExpression > Identifier[name=/Sync$/]",
+    // readFileSync()
+    ":not(MemberExpression) > Identifier[name=/Sync$/]",
+]
+
 module.exports = {
     meta: {
         type: "suggestion",
@@ -32,18 +50,17 @@ module.exports = {
     },
 
     create(context) {
-        const selector =
-            context.options[0] && context.options[0].allowAtRootLevel
-                ? ":function MemberExpression[property.name=/.*Sync$/]"
-                : "MemberExpression[property.name=/.*Sync$/]"
+        const selector = context.options[0]?.allowAtRootLevel
+            ? allowedAtRootLevelSelector
+            : disallowedAtRootLevelSelector
 
         return {
             [selector](node) {
                 context.report({
-                    node,
+                    node: node.parent,
                     messageId: "noSync",
                     data: {
-                        propertyName: node.property.name,
+                        propertyName: node.name,
                     },
                 })
             },

--- a/tests/lib/rules/no-sync.js
+++ b/tests/lib/rules/no-sync.js
@@ -15,13 +15,51 @@ new RuleTester().run("no-sync", rule, {
             options: [{ allowAtRootLevel: true }],
         },
         {
+            code: "var foo = fooSync;",
+            options: [{ allowAtRootLevel: true }],
+        },
+        {
             code: "if (true) {fs.fooSync();}",
+            options: [{ allowAtRootLevel: true }],
+        },
+        {
+            code: "if (true) {fooSync();}",
             options: [{ allowAtRootLevel: true }],
         },
     ],
     invalid: [
         {
             code: "var foo = fs.fooSync();",
+            errors: [
+                {
+                    messageId: "noSync",
+                    data: { propertyName: "fooSync" },
+                    type: "MemberExpression",
+                },
+            ],
+        },
+        {
+            code: "var foo = fs.fooSync.apply();",
+            errors: [
+                {
+                    messageId: "noSync",
+                    data: { propertyName: "fooSync" },
+                    type: "MemberExpression",
+                },
+            ],
+        },
+        {
+            code: "var foo = fooSync();",
+            errors: [
+                {
+                    messageId: "noSync",
+                    data: { propertyName: "fooSync" },
+                    type: "CallExpression",
+                },
+            ],
+        },
+        {
+            code: "var foo = fooSync.apply();",
             errors: [
                 {
                     messageId: "noSync",


### PR DESCRIPTION
This resolves named imports, or destructured requires:

```js
import { readFileSync } from 'node:fs';

const file = readFileSync('/file/path');
```

```js
const { readFileSync } = require('node:fs');

const file = readFileSync('/file/path');
```

---

This is the counterpoint to #128 and Option 1 for #102 (the simple option).