### PR TITLE
feat: Detect sync functions from built in node modules

### DIFF
--- a/lib/rules/no-sync.js
+++ b/lib/rules/no-sync.js
@@ -4,6 +4,129 @@
  */
 "use strict"
 
+const { builtinModules } = require("node:module")
+
+const modules = builtinModules
+    .filter(name => name.startsWith("_") === false)
+    .flatMap(name => [name, `node:${name}`])
+
+/*
+ * Build functional imports
+ * const fs = require('node:fs');
+ * const fs = await import('node:fs');
+ */
+const RequireDeclareExpressions = modules.map(name =>
+    [
+        `VariableDeclarator`,
+        `[init.callee.name="require"]`,
+        `[init.arguments.0.value="${name}"]`,
+        `[id.type="Identifier"]`,
+    ].join("")
+)
+const BabelImportDeclareExpressions = modules.map(name =>
+    [
+        `VariableDeclarator`,
+        `[init.argument.callee.type="Import"]`,
+        `[init.argument.arguments.0.value="${name}"]`,
+        `[id.type="Identifier"]`,
+    ].join("")
+)
+const EspreeImportDeclareExpressions = modules.map(name =>
+    [
+        `VariableDeclarator`,
+        `[init.argument.type="ImportExpression"]`,
+        `[init.argument.source.value="${name}"]`,
+        `[id.type="Identifier"]`,
+    ].join("")
+)
+
+/*
+ * Build ns/default imports
+ * import fs from 'node:fs';
+ * import * as fs from 'node:fs';
+ */
+const ImportDefaultSpecifiers = modules.map(
+    name => `ImportDeclaration[source.value="${name}"] ImportDefaultSpecifier`
+)
+const ImportNamespaceSpecifiers = modules.map(
+    name => `ImportDeclaration[source.value="${name}"] ImportNamespaceSpecifier`
+)
+
+/*
+ * Build aliasable imports
+ * import { readFileSync } from 'node:fs';
+ * import { readFileSync as readFile } from 'node:fs';
+ */
+const ImportAliasSpecifiers = modules.map(
+    name =>
+        `ImportDeclaration[source.value="${name}"] ImportSpecifier[imported.name=/Sync$/]`
+)
+
+/*
+ * Build functional deconstructed imports
+ * const { readFileSync } = require('node:fs');
+ * const { readFileSync: readFile } = require('node:fs');
+ * const { readFileSync } = await import('node:fs');
+ * const { readFileSync: readFile } = await import('node:fs');
+ */
+const RequireDeconstructExpressions = modules.map(name =>
+    [
+        `VariableDeclarator`,
+        `[init.callee.name="require"]`,
+        `[init.arguments.0.value="${name}"]`,
+        `[id.type="ObjectPattern"]`,
+    ].join("")
+)
+const BabelImportDeconstructExpressions = modules.map(name =>
+    [
+        `VariableDeclarator`,
+        `[init.argument.callee.type="Import"]`,
+        `[init.argument.arguments.0.value="${name}"]`,
+        `[id.type="ObjectPattern"]`,
+    ].join("")
+)
+const EspreeImportDeconstructExpressions = modules.map(name =>
+    [
+        `VariableDeclarator`,
+        `[init.argument.type="ImportExpression"]`,
+        `[init.argument.source.value="${name}"]`,
+        `[id.type="ObjectPattern"]`,
+    ].join("")
+)
+
+const ModuleDeclarations = [
+    RequireDeclareExpressions,
+    BabelImportDeclareExpressions,
+    EspreeImportDeclareExpressions,
+    ImportDefaultSpecifiers,
+    ImportNamespaceSpecifiers,
+].flat()
+
+const AliasDeclarations = [ImportAliasSpecifiers].flat()
+
+const DeconstructDeclarations = [
+    RequireDeconstructExpressions,
+    BabelImportDeconstructExpressions,
+    EspreeImportDeconstructExpressions,
+].flat()
+
+/**
+ * @param {import('eslint').Scope.Scope} scope The scope to check
+ * @returns {Boolean}
+ */
+function isFunctionScope(scope) {
+    while (scope != null) {
+        if (scope.type === "function") {
+            return true
+        }
+
+        scope = scope.upper
+    }
+
+    return false
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
         type: "suggestion",
@@ -27,25 +150,120 @@ module.exports = {
             },
         ],
         messages: {
-            noSync: "Unexpected sync method: '{{propertyName}}'.",
+            noSyncMember: "Unexpected sync method: '{{importName}}'.",
+            noSyncAlias:
+                "Unexpected sync method: '{{aliasName}}' ({{importName}}).",
         },
     },
 
     create(context) {
-        const selector =
-            context.options[0] && context.options[0].allowAtRootLevel
-                ? ":function MemberExpression[property.name=/.*Sync$/]"
-                : "MemberExpression[property.name=/.*Sync$/]"
+        const [options] = context.options
+        const syncRegex = /Sync$/u
 
         return {
-            [selector](node) {
-                context.report({
-                    node,
-                    messageId: "noSync",
-                    data: {
-                        propertyName: node.property.name,
-                    },
-                })
+            [ModuleDeclarations](node) {
+                const variables = context.sourceCode.getDeclaredVariables(node)
+
+                for (const variable of variables) {
+                    for (const reference of variable.references) {
+                        if (
+                            options?.allowAtRootLevel === true &&
+                            isFunctionScope(reference.from) === false
+                        ) {
+                            continue
+                        }
+
+                        /** @type {import('eslint').Rule.Node} */
+                        const memberExpression = reference.identifier.parent
+                        if (
+                            memberExpression.type !== "MemberExpression" ||
+                            syncRegex.test(memberExpression.property.name) ===
+                                false
+                        ) {
+                            continue
+                        }
+
+                        context.report({
+                            node: memberExpression.property,
+                            messageId: "noSyncMember",
+                            data: {
+                                importName: memberExpression.property.name,
+                            },
+                        })
+                    }
+                }
+            },
+            [AliasDeclarations](node) {
+                const variables = context.sourceCode.getDeclaredVariables(node)
+
+                for (const variable of variables) {
+                    for (const reference of variable.references ?? []) {
+                        if (
+                            options?.allowAtRootLevel === true &&
+                            isFunctionScope(reference.from) === false
+                        ) {
+                            continue
+                        }
+
+                        if (node.imported.name === node.local.name) {
+                            context.report({
+                                node: reference.identifier,
+                                messageId: "noSyncMember",
+                                data: { importName: node.imported.name },
+                            })
+                        } else {
+                            context.report({
+                                node: reference.identifier,
+                                messageId: "noSyncAlias",
+                                data: {
+                                    importName: node.imported.name,
+                                    aliasName: variables.at(0)?.name,
+                                },
+                            })
+                        }
+                    }
+                }
+            },
+            [DeconstructDeclarations](node) {
+                const variables = context.sourceCode.getDeclaredVariables(node)
+
+                for (const variable of variables) {
+                    const [identifier] = variable.identifiers
+                    const importName = identifier.parent.key.name
+
+                    for (const reference of variable?.references ?? []) {
+                        if (
+                            options?.allowAtRootLevel === true &&
+                            isFunctionScope(reference.from) === false
+                        ) {
+                            continue
+                        }
+
+                        if (
+                            reference.identifier.parent.type !==
+                            "CallExpression"
+                        ) {
+                            continue
+                        }
+
+                        if (importName === variable.name) {
+                            context.report({
+                                node: reference.identifier,
+                                messageId: "noSyncMember",
+                                data: { importName: importName },
+                            })
+                        } else {
+                            context.report({
+                                node: reference.identifier,
+                                messageId: "noSyncAlias",
+                                data: {
+                                    importName: importName,
+                                    aliasName: variable.name,
+                                },
+                            })
+                        }
+                    }
+                }
             },
         }
     },

--- a/lib/rules/no-sync.js
+++ b/lib/rules/no-sync.js
@@ -162,7 +162,9 @@ module.exports = {
 
         return {
             [ModuleDeclarations](node) {
-                const variables = context.sourceCode.getDeclaredVariables(node)
+                const variables =
+                    context.sourceCode?.getDeclaredVariables?.(node) ??
+                    context.getDeclaredVariables?.(node)
 
                 for (const variable of variables) {
                     for (const reference of variable.references) {
@@ -194,7 +196,9 @@ module.exports = {
                 }
             },
             [AliasDeclarations](node) {
-                const variables = context.sourceCode.getDeclaredVariables(node)
+                const variables =
+                    context.sourceCode?.getDeclaredVariables?.(node) ??
+                    context.getDeclaredVariables?.(node)
 
                 for (const variable of variables) {
                     for (const reference of variable.references ?? []) {
@@ -225,7 +229,9 @@ module.exports = {
                 }
             },
             [DeconstructDeclarations](node) {
-                const variables = context.sourceCode.getDeclaredVariables(node)
+                const variables =
+                    context.sourceCode?.getDeclaredVariables?.(node) ??
+                    context.getDeclaredVariables?.(node)
 
                 for (const variable of variables) {
                     const [identifier] = variable.identifiers

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "@eslint/js": "^8.43.0",
         "@types/eslint": "^8.44.2",
         "@typescript-eslint/parser": "^5.60.0",
+        "dedent": "^1.5.1",
         "esbuild": "^0.18.7",
         "eslint": "^8.43.0",
         "eslint-config-prettier": "^8.8.0",

--- a/tests/lib/rules/no-sync.js
+++ b/tests/lib/rules/no-sync.js
@@ -5,91 +5,262 @@
 "use strict"
 
 const RuleTester = require("eslint").RuleTester
+const dedent = require("dedent")
 const rule = require("../../../lib/rules/no-sync")
 
-new RuleTester().run("no-sync", rule, {
+new RuleTester({
+    parserOptions: {
+        ecmaVersion: 2015,
+        sourceType: "module",
+    },
+}).run("no-sync", rule, {
     valid: [
-        "var foo = fs.foo.foo();",
+        "var foo = readFile();",
+        dedent`
+            import { readFile as readFileSync } from 'node:fs';
+            readFileSync();
+        `,
         {
-            code: "var foo = fs.fooSync;",
+            code: dedent`
+                import { readFileSync } from 'node:fs';
+                readFileSync();
+            `,
             options: [{ allowAtRootLevel: true }],
         },
         {
-            code: "if (true) {fs.fooSync();}",
+            code: dedent`
+                import { readFileSync } from 'fs';
+                readFileSync();
+            `,
+            options: [{ allowAtRootLevel: true }],
+        },
+        {
+            code: dedent`
+                import { readFileSync } from 'fs';
+                if (true) {
+                    readFileSync();
+                }
+            `,
             options: [{ allowAtRootLevel: true }],
         },
     ],
     invalid: [
         {
-            code: "var foo = fs.fooSync();",
+            code: dedent`
+                import { readFileSync } from 'fs';
+                readFileSync();
+            `,
             errors: [
                 {
-                    messageId: "noSync",
-                    data: { propertyName: "fooSync" },
-                    type: "MemberExpression",
+                    messageId: "noSyncMember",
+                    data: { importName: "readFileSync" },
                 },
             ],
         },
         {
-            code: "var foo = fs.fooSync();",
-            options: [{ allowAtRootLevel: false }],
+            code: dedent`
+                import { readFileSync } from 'fs';
+                if (true) {
+                    readFileSync();
+                }
+            `,
             errors: [
                 {
-                    messageId: "noSync",
-                    data: { propertyName: "fooSync" },
-                    type: "MemberExpression",
+                    messageId: "noSyncMember",
+                    data: { importName: "readFileSync" },
                 },
             ],
         },
         {
-            code: "if (true) {fs.fooSync();}",
+            code: dedent`
+                import { readFileSync } from 'fs';
+                function soSomethingSync() {
+                    readFileSync();
+                }
+            `,
             errors: [
                 {
-                    messageId: "noSync",
-                    data: { propertyName: "fooSync" },
-                    type: "MemberExpression",
+                    messageId: "noSyncMember",
+                    data: { importName: "readFileSync" },
+                },
+            ],
+        },
+
+        {
+            code: dedent`
+                import { readFileSync } from 'node:fs';
+                readFileSync();
+            `,
+            errors: [
+                {
+                    messageId: "noSyncMember",
+                    data: { importName: "readFileSync" },
                 },
             ],
         },
         {
-            code: "var foo = fs.fooSync;",
+            code: dedent`
+                import fs from 'node:fs';
+                fs.readFileSync();
+            `,
             errors: [
                 {
-                    messageId: "noSync",
-                    data: { propertyName: "fooSync" },
-                    type: "MemberExpression",
+                    messageId: "noSyncMember",
+                    data: { importName: "readFileSync" },
                 },
             ],
         },
         {
-            code: "function someFunction() {fs.fooSync();}",
+            code: dedent`
+                import * as fs from 'node:fs';
+                fs.readFileSync();
+            `,
             errors: [
                 {
-                    messageId: "noSync",
-                    data: { propertyName: "fooSync" },
-                    type: "MemberExpression",
+                    messageId: "noSyncMember",
+                    data: { importName: "readFileSync" },
                 },
             ],
         },
         {
-            code: "function someFunction() {fs.fooSync();}",
+            code: dedent`
+                const { readFileSync } = require('node:fs');
+                readFileSync();
+            `,
+            errors: [
+                {
+                    messageId: "noSyncMember",
+                    data: { importName: "readFileSync" },
+                },
+            ],
+        },
+        {
+            code: dedent`
+                const fs = require('node:fs');
+                fs.readFileSync();
+            `,
+            errors: [
+                {
+                    messageId: "noSyncMember",
+                    data: { importName: "readFileSync" },
+                },
+            ],
+        },
+
+        {
+            code: dedent`
+                import { readFileSync as readFile } from 'node:fs';
+                readFile();
+            `,
+            errors: [
+                {
+                    messageId: "noSyncAlias",
+                    data: {
+                        importName: "readFileSync",
+                        aliasName: "readFile",
+                    },
+                },
+            ],
+        },
+        {
+            code: dedent`
+                const { readFileSync: readFile } = require('node:fs');
+                readFile();
+            `,
+            errors: [
+                {
+                    messageId: "noSyncAlias",
+                    data: {
+                        importName: "readFileSync",
+                        aliasName: "readFile",
+                    },
+                },
+            ],
+        },
+
+        {
+            code: dedent`
+                import { readFileSync } from 'fs';
+                function something() {
+                    readFileSync();
+                }
+            `,
             options: [{ allowAtRootLevel: true }],
             errors: [
                 {
-                    messageId: "noSync",
-                    data: { propertyName: "fooSync" },
-                    type: "MemberExpression",
+                    messageId: "noSyncMember",
+                    data: { importName: "readFileSync" },
                 },
             ],
         },
         {
-            code: "var a = function someFunction() {fs.fooSync();}",
+            code: dedent`
+                const { readFileSync } = require('fs');
+                function something() {
+                    readFileSync();
+                }
+            `,
             options: [{ allowAtRootLevel: true }],
             errors: [
                 {
-                    messageId: "noSync",
-                    data: { propertyName: "fooSync" },
-                    type: "MemberExpression",
+                    messageId: "noSyncMember",
+                    data: { importName: "readFileSync" },
+                },
+            ],
+        },
+        {
+            code: dedent`
+                import fs from 'node:fs';
+                function something() {
+                    fs.readFileSync();
+                }
+            `,
+            options: [{ allowAtRootLevel: true }],
+            errors: [
+                {
+                    messageId: "noSyncMember",
+                    data: { importName: "readFileSync" },
+                },
+            ],
+        },
+        {
+            code: dedent`
+                const fs = require('fs');
+                function something() {
+                    fs.readFileSync();
+                }
+            `,
+            options: [{ allowAtRootLevel: true }],
+            errors: [
+                {
+                    messageId: "noSyncMember",
+                    data: { importName: "readFileSync" },
+                },
+            ],
+        },
+
+        {
+            code: dedent`
+                import { readFileSync } from 'fs';
+                readFileSync.apply(null, '/something');
+            `,
+            errors: [
+                {
+                    messageId: "noSyncMember",
+                    data: { importName: "readFileSync" },
+                },
+            ],
+        },
+
+        {
+            code: dedent`
+                import * as fs from 'fs';
+                fs.readFileSync.apply(null, '/something');
+            `,
+            errors: [
+                {
+                    messageId: "noSyncMember",
+                    data: { importName: "readFileSync" },
                 },
             ],
         },


### PR DESCRIPTION
This is a different strategy to detect "Sync" functions by looking for the builtin node imports. Then we look for the usage of the function from there.

This means we can detect aliases like this too:
```js
import { readFileSync as readFile } from 'node:fs';

readFile();
```

The tradeoff is that npm packages can now export Sync functions, eg:
```js
import * as magic from 'npm:magic-module';

magic.performMagicSync();
```

This is the counterpoint to #127 and Option 2 for #102 (the complex option).