### PR TITLE
docs: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,52 @@
+name: "\U0001F41E Report a problem"
+description: "Report an issue with eslint-plugin-n"
+title: "Bug: (fill in)"
+labels:
+  - bug
+body:
+- type: markdown
+  attributes:
+    value: By opening an issue, you agree to abide by the [Open JS Foundation Code of Conduct](https://eslint.org/conduct).
+- type: textarea
+  attributes:
+    label: Environment
+    description: |
+      Please tell us about how you're running ESLint.
+    value: |
+        Node version:
+        npm version:
+        ESLint version:
+        eslint-plugin-n version:
+        Operating System:
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: What rule do you want to report?
+    description: Please provide the name of the rule you're having problems with.
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: Link to Minimal Reproducible Example
+    description: 'Link to a [playground](https://eslint-online-playground.netlify.app/), [StackBlitz](https://stackblitz.com), or GitHub repo with a minimal reproduction of the problem. **A minimal reproduction is required** so that others can help debug your issue. If a report is vague (e.g. just a generic error message) and has no reproduction, it may be auto-closed.'
+    placeholder: 'https://eslint-online-playground.netlify.app/#'
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: What did you expect to happen?
+    description: |
+      You can use Markdown in this field.
+  validations:
+    required: true
+- type: checkboxes
+  attributes:
+    label: Participation
+    options:
+      - label: I am willing to submit a pull request for this issue.
+        required: false
+- type: textarea
+  attributes:
+    label: Additional comments
+    description: Is there anything else that's important for the team to know?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/new-rule.yml
+++ b/.github/ISSUE_TEMPLATE/new-rule.yml
@@ -1,0 +1,41 @@
+name: "\U0001F680 Propose a new rule"
+description: "Propose a new rule to be added to the plugin"
+title: "New Rule: (fill in)"
+labels:
+  - rule
+  - feature
+body:
+- type: markdown
+  attributes:
+    value: By opening an issue, you agree to abide by the [Open JS Foundation Code of Conduct](https://eslint.org/conduct).
+- type: input
+  attributes:
+    label: Rule details
+    description: What should the new rule do?
+  validations:
+    required: true
+- type: dropdown
+  attributes:
+    label: What type of rule is this?
+    options:
+      - Warns about a potential problem
+      - Suggests an alternate way of doing something
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Example code
+    description: Please provide some example JavaScript code that this rule will warn about. This field will render as JavaScript.
+    render: js
+  validations:
+    required: true
+- type: checkboxes
+  attributes:
+    label: Participation
+    options:
+      - label: I am willing to submit a pull request to implement this rule.
+        required: false
+- type: textarea
+  attributes:
+    label: Additional comments
+    description: Is there anything else that's important for the team to know?


### PR DESCRIPTION
it's mainly modified from eslint's issue templates. the repro link was changed to eslint-online-playground. A big thanks to @ota-meshi!