### PR TITLE
feat: Export the moduleType from ImportTarget

### DIFF
--- a/lib/rules/file-extension-in-import.js
+++ b/lib/rules/file-extension-in-import.js
@@ -8,9 +8,6 @@ const path = require("path")
 const fs = require("fs")
 const mapTypescriptExtension = require("../util/map-typescript-extension")
 const visitImport = require("../util/visit-import")
-const packageNamePattern = /^(?:@[^/\\]+[/\\])?[^/\\]+$/u
-const corePackageOverridePattern =
-    /^(?:assert|async_hooks|buffer|child_process|cluster|console|constants|crypto|dgram|dns|domain|events|fs|http|http2|https|inspector|module|net|os|path|perf_hooks|process|punycode|querystring|readline|repl|stream|string_decoder|sys|timers|tls|trace_events|tty|url|util|v8|vm|worker_threads|zlib)[/\\]$/u
 
 /**
  * Get all file extensions of the files which have the same basename.
@@ -67,13 +64,13 @@ module.exports = {
         const defaultStyle = context.options[0] || "always"
         const overrideStyle = context.options[1] || {}
 
-        function verify({ filePath, name, node }) {
+        /**
+         * @param {import("../util/import-target.js")} target
+         * @returns {void}
+         */
+        function verify({ filePath, name, node, moduleType }) {
             // Ignore if it's not resolved to a file or it's a bare module.
-            if (
-                !filePath ||
-                packageNamePattern.test(name) ||
-                corePackageOverridePattern.test(name)
-            ) {
+            if (moduleType !== "relative" && moduleType !== "absolute") {
                 return
             }
 

--- a/lib/util/import-target.js
+++ b/lib/util/import-target.js
@@ -6,6 +6,7 @@
 
 const path = require("path")
 const { pathToFileURL, fileURLToPath } = require("url")
+const { isBuiltin } = require("module")
 const resolve = require("resolve")
 const {
     defaultResolve: importResolve,
@@ -72,6 +73,14 @@ function getFilePath(isModule, id, options, moduleType) {
     }
 }
 
+function isNodeModule(name, options) {
+    try {
+        return require.resolve(name, options).startsWith(path.sep)
+    } catch {
+        return false
+    }
+}
+
 /**
  * Gets the module name of a given path.
  *
@@ -114,6 +123,24 @@ module.exports = class ImportTarget {
          * @type {string}
          */
         this.name = name
+
+        /**
+         * What type of module is this
+         * @type {'unknown'|'relative'|'absolute'|'node'|'npm'|'http'|void}
+         */
+        this.moduleType = "unknown"
+
+        if (name.startsWith("./") || name.startsWith(".\\")) {
+            this.moduleType = "relative"
+        } else if (name.startsWith("/") || name.startsWith("\\")) {
+            this.moduleType = "absolute"
+        } else if (isBuiltin(name)) {
+            this.moduleType = "node"
+        } else if (isNodeModule(name, options)) {
+            this.moduleType = "npm"
+        } else if (name.startsWith("http://") || name.startsWith("https://")) {
+            this.moduleType = "http"
+        }
 
         /**
          * The full path of this import target.

--- a/tests/lib/rules/file-extension-in-import.js
+++ b/tests/lib/rules/file-extension-in-import.js
@@ -155,6 +155,23 @@ new RuleTester({
             options: ["never", { ".json": "always" }],
         },
 
+        // Ignore sub-paths of modules
+        {
+            filename: fixture("test.js"),
+            code: "import '@apollo/client/core'",
+            options: ["always"],
+        },
+        {
+            filename: fixture("test.js"),
+            code: "import 'yargs/helpers'",
+            options: ["always"],
+        },
+        {
+            filename: fixture("test.js"),
+            code: "import 'firebase-functions/v1/auth'",
+            options: ["always"],
+        },
+
         // typescriptExtensionMap
         {
             filename: fixture("test.tsx"),


### PR DESCRIPTION
This is a slightly different approach to solve #21.

In this case we only try to add extensions to relative and absolute paths, with the detection of the moduleTypes done inside the `ImportTarget`