### PR TITLE
feat: Add syntax check for ES2021 to no-unsupported-features/es-syntax rule

### DIFF
--- a/lib/rules/no-unsupported-features/es-syntax.js
+++ b/lib/rules/no-unsupported-features/es-syntax.js
@@ -402,6 +402,28 @@ const features = {
             },
         ],
     },
+
+    //--------------------------------------------------------------------------
+    // ES2021
+    //--------------------------------------------------------------------------
+    logicalAssignmentOperators: {
+        ruleId: "no-logical-assignment-operators",
+        cases: [
+            {
+                supported: "15.0.0",
+                messageId: "no-logical-assignment-operators",
+            },
+        ],
+    },
+    numericSeparators: {
+        ruleId: "no-numeric-separators",
+        cases: [
+            {
+                supported: "12.5.0",
+                messageId: "no-numeric-separators",
+            },
+        ],
+    },
 }
 const keywords = Object.keys(features)
 
@@ -654,6 +676,14 @@ module.exports = {
                 "Optional chainings are not supported until Node.js {{supported}}. The configured version range is '{{version}}'.",
             "no-nullish-coalescing-operators":
                 "Nullish coalescing operators are not supported until Node.js {{supported}}. The configured version range is '{{version}}'.",
+
+            //------------------------------------------------------------------
+            // ES2021
+            //------------------------------------------------------------------
+            "no-logical-assignment-operators":
+                "Logical assignment operators are not supported until Node.js {{supported}}. The configured version range is '{{version}}'.",
+            "no-numeric-separators":
+                "Numeric separators are not supported until Node.js {{supported}}. The configured version range is '{{version}}'.",
         },
     },
     create(context) {

--- a/tests/lib/rules/no-path-concat.js
+++ b/tests/lib/rules/no-path-concat.js
@@ -169,5 +169,3 @@ new RuleTester({
         },
     ],
 })
-
-/*eslint-enable no-template-curly-in-string */

--- a/tests/lib/rules/no-unsupported-features/es-syntax.js
+++ b/tests/lib/rules/no-unsupported-features/es-syntax.js
@@ -10,12 +10,19 @@ const { builtin } = require("globals")
 const { Range } = require("semver")
 const rule = require("../../../../lib/rules/no-unsupported-features/es-syntax")
 
-const ES2020Supported = (() => {
-    const config = { parserOptions: { ecmaVersion: 2020 } }
+const ES2021Supported = (() => {
+    const config = { parserOptions: { ecmaVersion: 2021 } }
     const messages = new Linter().verify("0n", config)
     return messages.length === 0
 })()
-const ecmaVersion = ES2020Supported ? 2020 : 2019
+const ES2020Supported =
+    ES2021Supported ||
+    (() => {
+        const config = { parserOptions: { ecmaVersion: 2020 } }
+        const messages = new Linter().verify("0n", config)
+        return messages.length === 0
+    })()
+const ecmaVersion = ES2021Supported ? 2021 : ES2020Supported ? 2020 : 2019
 
 /**
  * Makes a file path to a fixture.
@@ -1553,7 +1560,6 @@ ruleTester.run(
                     ],
                 },
             ],
-            /*eslint-enable no-template-curly-in-string */
         },
         {
             keyword: "unicodeCodePointEscapes",
@@ -2593,6 +2599,93 @@ ruleTester.run(
         },
 
         //----------------------------------------------------------------------
+        // ES2021
+        //----------------------------------------------------------------------
+        {
+            keyword: "logicalAssignmentOperators",
+            requiredEcmaVersion: 2021,
+            valid: [
+                {
+                    code: "a ||= b",
+                    options: [{ version: "15.0.0" }],
+                },
+                {
+                    code: "a &&= b",
+                    options: [{ version: "15.0.0" }],
+                },
+                {
+                    code: "a ??= b",
+                    options: [{ version: "15.0.0" }],
+                },
+            ],
+            invalid: [
+                {
+                    code: "a ||= b",
+                    options: [{ version: "14.0.0" }],
+                    errors: [
+                        {
+                            messageId: "no-logical-assignment-operators",
+                            data: {
+                                supported: "15.0.0",
+                                version: "14.0.0",
+                            },
+                        },
+                    ],
+                },
+                {
+                    code: "a &&= b",
+                    options: [{ version: "14.0.0" }],
+                    errors: [
+                        {
+                            messageId: "no-logical-assignment-operators",
+                            data: {
+                                supported: "15.0.0",
+                                version: "14.0.0",
+                            },
+                        },
+                    ],
+                },
+                {
+                    code: "a ??= b",
+                    options: [{ version: "14.0.0" }],
+                    errors: [
+                        {
+                            messageId: "no-logical-assignment-operators",
+                            data: {
+                                supported: "15.0.0",
+                                version: "14.0.0",
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            keyword: "numericSeparators",
+            requiredEcmaVersion: 2021,
+            valid: [
+                {
+                    code: "a = 123_456_789",
+                    options: [{ version: "12.5.0" }],
+                },
+            ],
+            invalid: [
+                {
+                    code: "a = 123_456_789",
+                    options: [{ version: "12.4.0" }],
+                    errors: [
+                        {
+                            messageId: "no-numeric-separators",
+                            data: {
+                                supported: "12.5.0",
+                                version: "12.4.0",
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+        //----------------------------------------------------------------------
         // MISC
         //----------------------------------------------------------------------
         {
@@ -2663,7 +2756,7 @@ ruleTester.run(
                 {
                     filename: fixture("invalid/a.js"),
                     code: "var a = { ...obj }",
-                    options: [{version: '>=8.0.0'}],
+                    options: [{ version: ">=8.0.0" }],
                     errors: [
                         {
                             messageId: "no-rest-spread-properties",
@@ -2684,7 +2777,7 @@ ruleTester.run(
                 {
                     filename: fixture("nothing/a.js"),
                     code: "var a = { ...obj }",
-                    options: [{version: '>=8.0.0'}],
+                    options: [{ version: ">=8.0.0" }],
                     errors: [
                         {
                             messageId: "no-rest-spread-properties",


### PR DESCRIPTION
refs: https://github.com/eslint-community/eslint-plugin-n/issues/34
the change was borrowed from https://github.com/mysticatea/eslint-plugin-node/pull/283
credits goes to @ota-meshi :)