### PR TITLE
feat: Add builtins check for ES2021 to no-unsupported-features/es-builtins rule

### DIFF
--- a/docs/rules/no-unsupported-features/es-builtins.md
+++ b/docs/rules/no-unsupported-features/es-builtins.md
@@ -48,6 +48,13 @@ The `"ignores"` option accepts an array of the following strings.
 
 <details>
 
+**ES2021:**
+
+- `"AggregateError"`
+- `"Promise.any"`
+- `"WeakRef"`
+- `"FinalizationRegistry"`
+
 **ES2020:**
 
 - `"BigInt"`

--- a/lib/rules/no-unsupported-features/es-builtins.js
+++ b/lib/rules/no-unsupported-features/es-builtins.js
@@ -14,12 +14,18 @@ const getConfiguredNodeVersion = require("../../util/get-configured-node-version
 
 const trackMap = {
     globals: {
+        AggregateError: {
+            [READ]: { supported: "15.0.0" },
+        },
         Array: {
             from: { [READ]: { supported: "4.0.0" } },
             of: { [READ]: { supported: "4.0.0" } },
         },
         BigInt: {
             [READ]: { supported: "10.4.0" },
+        },
+        FinalizationRegistry: {
+            [READ]: { supported: "14.6.0" },
         },
         Map: {
             [READ]: { supported: "0.12.0" },
@@ -67,6 +73,7 @@ const trackMap = {
         Promise: {
             [READ]: { supported: "0.12.0" },
             allSettled: { [READ]: { supported: "12.9.0" } },
+            any: { [READ]: { supported: "15.0.0" } },
         },
         Proxy: {
             [READ]: { supported: "6.0.0" },
@@ -122,6 +129,9 @@ const trackMap = {
         },
         WeakMap: {
             [READ]: { supported: "0.12.0" },
+        },
+        WeakRef: {
+            [READ]: { supported: "14.6.0" },
         },
         WeakSet: {
             [READ]: { supported: "0.12.0" },

--- a/tests/lib/rules/no-unsupported-features/es-builtins.js
+++ b/tests/lib/rules/no-unsupported-features/es-builtins.js
@@ -73,6 +73,31 @@ ruleTester.run(
     rule,
     concat([
         {
+            keyword: "AggregateError",
+            valid: [
+                {
+                    code: "if (error instanceof AggregateError) {}",
+                    options: [{ version: "15.0.0" }],
+                },
+            ],
+            invalid: [
+                {
+                    code: "if (error instanceof AggregateError) {}",
+                    options: [{ version: "14.0.0" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "AggregateError",
+                                supported: "15.0.0",
+                                version: "14.0.0",
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+        {
             keyword: "Array.from",
             valid: [
                 {
@@ -179,6 +204,31 @@ ruleTester.run(
                                 name: "BigInt",
                                 supported: "10.4.0",
                                 version: "10.3.0",
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            keyword: "FinalizationRegistry",
+            valid: [
+                {
+                    code: "new FinalizationRegistry(() => {})",
+                    options: [{ version: "14.6.0" }],
+                },
+            ],
+            invalid: [
+                {
+                    code: "new FinalizationRegistry(() => {})",
+                    options: [{ version: "14.5.0" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "FinalizationRegistry",
+                                supported: "14.6.0",
+                                version: "14.5.0",
                             },
                         },
                     ],
@@ -1210,6 +1260,49 @@ ruleTester.run(
             ],
         },
         {
+            keyword: "Promise.any",
+            valid: [
+                {
+                    code: "(function(Promise) { Promise.any }(a))",
+                    options: [{ version: "14.0.0" }],
+                },
+                {
+                    code: "Promise.any",
+                    options: [{ version: "15.0.0" }],
+                },
+            ],
+            invalid: [
+                {
+                    code: "Promise.any",
+                    options: [{ version: "14.0.0" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "Promise.any",
+                                supported: "15.0.0",
+                                version: "14.0.0",
+                            },
+                        },
+                    ],
+                },
+                {
+                    code: "function wrap() { Promise.any }",
+                    options: [{ version: "14.0.0" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "Promise.any",
+                                supported: "15.0.0",
+                                version: "14.0.0",
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+        {
             keyword: "Proxy",
             valid: [
                 {
@@ -2000,6 +2093,49 @@ ruleTester.run(
                                 name: "WeakMap",
                                 supported: "0.12.0",
                                 version: "0.11.9",
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            keyword: "WeakRef",
+            valid: [
+                {
+                    code: "(function(WeakRef) { WeakRef }(a))",
+                    options: [{ version: "14.5.0" }],
+                },
+                {
+                    code: "WeakRef",
+                    options: [{ version: "14.6.0" }],
+                },
+            ],
+            invalid: [
+                {
+                    code: "WeakRef",
+                    options: [{ version: "14.5.0" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "WeakRef",
+                                supported: "14.6.0",
+                                version: "14.5.0",
+                            },
+                        },
+                    ],
+                },
+                {
+                    code: "function wrap() { WeakRef }",
+                    options: [{ version: "14.5.0" }],
+                    errors: [
+                        {
+                            messageId: "unsupported",
+                            data: {
+                                name: "WeakRef",
+                                supported: "14.6.0",
+                                version: "14.5.0",
                             },
                         },
                     ],


### PR DESCRIPTION
refs: https://github.com/eslint-community/eslint-plugin-n/issues/34
the change was borrowed from https://github.com/mysticatea/eslint-plugin-node/pull/284

credits goes to @ota-meshi. :)