### PR TITLE
chore: add non-rule-change issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/non-rule-change.yml
+++ b/.github/ISSUE_TEMPLATE/non-rule-change.yml
@@ -1,0 +1,47 @@
+name: "\U0001F680 Request a change (not rule-related)"
+description: "Request a change that is not a bug fix, rule change, or new rule"
+title: "Change Request: (fill in)"
+labels:
+  - enhancement
+  - core
+body:
+- type: markdown
+  attributes:
+    value: By opening an issue, you agree to abide by the [Open JS Foundation Code of Conduct](https://eslint.org/conduct).
+- type: input
+  attributes:
+    label: eslint-plugin-n version
+    description: |
+      What version of eslint-plugin-n are you currently using?
+    placeholder: |
+      e.g. v16.0.0
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: What problem do you want to solve?
+    description: |
+      Please explain your use case in as much detail as possible.
+    placeholder: |
+      ESLint currently...
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: What do you think is the correct solution?
+    description: |
+      Please explain how you'd like to change to address the problem.
+    placeholder: |
+      I'd like to...
+  validations:
+    required: true
+- type: checkboxes
+  attributes:
+    label: Participation
+    options:
+      - label: I am willing to submit a pull request for this change.
+        required: false
+- type: textarea
+  attributes:
+    label: Additional comments
+    description: Is there anything else that's important for the team to know?


### PR DESCRIPTION
There is already an issue template for rule-related changes, but some changes do not apply to it. Therefore, this pull request adds a new one.