### PR TITLE
fix(no-unsupported-features): Remove use of `static` as a variable

### DIFF
--- a/lib/unsupported-features/node-builtins-modules/events.js
+++ b/lib/unsupported-features/node-builtins-modules/events.js
@@ -1,7 +1,7 @@
 const { READ } = require("@eslint-community/eslint-utils")
 
 /** @type {import('../types.js').SupportVersionTree} */
-const static = {
+const EventEmitterStatic = {
     defaultMaxListeners: { [READ]: { supported: ["0.11.2"] } },
     errorMonitor: { [READ]: { supported: ["13.6.0", "12.17.0"] } },
     captureRejections: {
@@ -43,13 +43,13 @@ const events = {
     },
     EventEmitter: {
         [READ]: { supported: ["0.1.26"] },
-        ...static,
+        ...EventEmitterStatic,
     },
     EventEmitterAsyncResource: {
         [READ]: { supported: ["17.4.0", "16.14.0"] },
-        ...static,
+        ...EventEmitterStatic,
     },
-    ...static,
+    ...EventEmitterStatic,
 }
 
 /** @type {import('../types.js').SupportVersionTree} */


### PR DESCRIPTION
Thank you @alex-kinokon for spotting this!