### PR TITLE
feat(shebang): add support for env's split-string option

### DIFF
--- a/lib/rules/shebang.js
+++ b/lib/rules/shebang.js
@@ -13,7 +13,8 @@ const getNpmignore = require("../util/get-npmignore")
 
 const NODE_SHEBANG = "#!/usr/bin/env node\n"
 const SHEBANG_PATTERN = /^(#!.+?)?(\r)?\n/u
-const NODE_SHEBANG_PATTERN = /#!\/usr\/bin\/env(?: -S)? node(?: [^\r\n]+?)?\n/u
+const NODE_SHEBANG_PATTERN =
+    /^#!\/usr\/bin\/env(?: -\S+)*(?: \S+=\S+)* node(?: [^\r\n]+?)?\n/u
 
 function simulateNodeResolutionAlgorithm(filePath, binField) {
     const possibilities = [filePath]

--- a/lib/rules/shebang.js
+++ b/lib/rules/shebang.js
@@ -13,7 +13,7 @@ const getNpmignore = require("../util/get-npmignore")
 
 const NODE_SHEBANG = "#!/usr/bin/env node\n"
 const SHEBANG_PATTERN = /^(#!.+?)?(\r)?\n/u
-const NODE_SHEBANG_PATTERN = /#!\/usr\/bin\/env node(?: [^\r\n]+?)?\n/u
+const NODE_SHEBANG_PATTERN = /#!\/usr\/bin\/env(?: -S)? node(?: [^\r\n]+?)?\n/u
 
 function simulateNodeResolutionAlgorithm(filePath, binField) {
     const possibilities = [filePath]

--- a/lib/rules/shebang.js
+++ b/lib/rules/shebang.js
@@ -14,7 +14,7 @@ const getNpmignore = require("../util/get-npmignore")
 const NODE_SHEBANG = "#!/usr/bin/env node\n"
 const SHEBANG_PATTERN = /^(#!.+?)?(\r)?\n/u
 const NODE_SHEBANG_PATTERN =
-    /^#!\/usr\/bin\/env(?: -\S+)*(?: \S+=\S+)* node(?: [^\r\n]+?)?\n/u
+    /^#!\/usr\/bin\/env(?: -\S+)*(?: [^\s=-]+=\S+)* node(?: [^\r\n]+?)?\n/u
 
 function simulateNodeResolutionAlgorithm(filePath, binField) {
     const possibilities = [filePath]

--- a/tests/lib/rules/shebang.js
+++ b/tests/lib/rules/shebang.js
@@ -42,6 +42,16 @@ ruleTester.run("shebang", rule, {
             code: "#!/usr/bin/env node\nhello();",
         },
         {
+            name: "string-bin/bin/test.js",
+            filename: fixture("string-bin/bin/test.js"),
+            code: "#!/usr/bin/env -S node\nhello();",
+        },
+        {
+            name: "string-bin/bin/test.js",
+            filename: fixture("string-bin/bin/test.js"),
+            code: "#!/usr/bin/env -S node --loader tsm\nhello();",
+        },
+        {
             name: "object-bin/bin/c.js",
             filename: fixture("object-bin/bin/c.js"),
             code: "hello();",

--- a/tests/lib/rules/shebang.js
+++ b/tests/lib/rules/shebang.js
@@ -52,6 +52,21 @@ ruleTester.run("shebang", rule, {
             code: "#!/usr/bin/env -S node --loader tsm\nhello();",
         },
         {
+            name: "string-bin/bin/test.js",
+            filename: fixture("string-bin/bin/test.js"),
+            code: "#!/usr/bin/env --ignore-environment node\nhello();",
+        },
+        {
+            name: "string-bin/bin/test.js",
+            filename: fixture("string-bin/bin/test.js"),
+            code: "#!/usr/bin/env -i -S node --loader tsm\nhello();",
+        },
+        {
+            name: "string-bin/bin/test.js",
+            filename: fixture("string-bin/bin/test.js"),
+            code: "#!/usr/bin/env --block-signal=SIGINT -S FOO=bar node --loader tsm\nhello();",
+        },
+        {
             name: "object-bin/bin/c.js",
             filename: fixture("object-bin/bin/c.js"),
             code: "hello();",


### PR DESCRIPTION
This is useful for passing arguments to node