### PR TITLE
fix: explicitly support ESLint 9.0.0 pre-releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "configs/"
     ],
     "peerDependencies": {
-        "eslint": ">=8.23.0"
+        "eslint": "^8.23.0 || >=9.0.0-0"
     },
     "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",


### PR DESCRIPTION
Fixes eslint-community/eslint-plugin-n#197 using the solution from eslint-community/eslint-utils#206

Only time that `^8.23.0 || >=9.0.0-0` may cause an issue is if we ship a stable version of `17.0.0` before ESLint ships a stable version of `9.0.0`.

We may want to keep `>=8.23.0` in our stable releases and only set it to `^8.23.0 || >=9.0.0-0` in our pre-releases.