### PR TITLE
fix: prefer-node-protocol: not first target

### DIFF
--- a/lib/rules/prefer-node-protocol.js
+++ b/lib/rules/prefer-node-protocol.js
@@ -124,7 +124,7 @@ module.exports = {
                             !isBuiltinModule(value) ||
                             !isBuiltinModule(`node:${value}`)
                         ) {
-                            return
+                            continue
                         }
 
                         context.report({

--- a/tests/lib/rules/prefer-node-protocol.js
+++ b/tests/lib/rules/prefer-node-protocol.js
@@ -191,6 +191,17 @@ new RuleTester({
             output: "const fs = require('node:fs/promises')",
             errors: ["Prefer `node:fs/promises` over `fs/promises`."],
         },
+        {
+            code: `
+                const express = require('express');
+                const fs = require('fs/promises');
+            `,
+            output: `
+                const express = require('express');
+                const fs = require('node:fs/promises');
+            `,
+            errors: ["Prefer `node:fs/promises` over `fs/promises`."],
+        },
 
         // check enabling by supported Node.js versions
         {


### PR DESCRIPTION
Targets ignored completely when first not node built-in. Fixed it.