### PR TITLE
chore: use `ts-ignore-import` to lighten the dependencies

### DIFF
--- a/lib/eslint-utils.d.ts
+++ b/lib/eslint-utils.d.ts
@@ -1,7 +1,6 @@
 declare module "eslint-plugin-es-x" {
-    export const rules: NonNullable<
-// @ts-ignore
-import('eslint').ESLint.Plugin["rules"]>;
+    // @ts-ignore
+    export const rules: NonNullable<import('eslint').ESLint.Plugin["rules"]>;
 }
 
 declare module "@eslint-community/eslint-utils" {

--- a/lib/eslint-utils.d.ts
+++ b/lib/eslint-utils.d.ts
@@ -1,9 +1,13 @@
 declare module "eslint-plugin-es-x" {
-    export const rules: NonNullable<import('eslint').ESLint.Plugin["rules"]>;
+    export const rules: NonNullable<
+// @ts-ignore
+import('eslint').ESLint.Plugin["rules"]>;
 }
 
 declare module "@eslint-community/eslint-utils" {
+    // @ts-ignore
     import * as estree from 'estree';
+    // @ts-ignore
     import * as eslint from 'eslint';
 
     type Node = estree.Node | estree.Expression;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     },
     "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/eslint": "^8.56.2",
         "enhanced-resolve": "^5.15.0",
         "eslint-plugin-es-x": "^7.5.0",
         "get-tsconfig": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "punycode": "^2.3.0",
         "release-it": "^17.0.0",
         "rimraf": "^5.0.1",
+        "ts-ignore-import": "^4.0.0",
         "type-fest": "^4.9.0",
         "typescript": "^5.1.3"
     },
@@ -65,7 +66,7 @@
         "lint:js": "eslint .",
         "new": "node scripts/new-rule",
         "postversion": "git push && git push --tags",
-        "prepack": "tsc --emitDeclarationOnly",
+        "prepack": "tsc --emitDeclarationOnly && ts-ignore-import 'types/**/*.d.ts' --allow=@eslint-community/eslint-utils --allow=semver --allow=get-tsconfig",
         "prepare": "husky",
         "preversion": "npm test",
         "test": "run-p lint:* test:types test:tests",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "punycode": "^2.3.0",
         "release-it": "^17.0.0",
         "rimraf": "^5.0.1",
-        "ts-ignore-import": "^4.0.0",
+        "ts-ignore-import": "^4.0.1",
         "type-fest": "^4.9.0",
         "typescript": "^5.1.3"
     },


### PR DESCRIPTION
Fixes eslint-community/eslint-plugin-n#213

It finds and ignores 5 dependencies across 117 files: @typescript-eslint/typescript-estree, eslint, estree, json-schema, type-fest