### PR TITLE
feat: remove "is-builtin-module" dependency (fixes #232)

### DIFF
--- a/lib/rules/prefer-node-protocol.js
+++ b/lib/rules/prefer-node-protocol.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const isBuiltinModule = require("is-builtin-module")
+const { isBuiltin } = require("node:module")
 const getConfiguredNodeVersion = require("../util/get-configured-node-version")
 const getSemverRange = require("../util/get-semver-range")
 const visitImport = require("../util/visit-import")
@@ -150,8 +150,8 @@ module.exports = {
                         if (
                             typeof value !== "string" ||
                             value.startsWith("node:") ||
-                            !isBuiltinModule(value) ||
-                            !isBuiltinModule(`node:${value}`)
+                            !isBuiltin(value) ||
+                            !isBuiltin(`node:${value}`)
                         ) {
                             continue
                         }

--- a/lib/util/extend-trackmap-with-node-prefix.js
+++ b/lib/util/extend-trackmap-with-node-prefix.js
@@ -1,6 +1,6 @@
 "use strict"
 
-const isBuiltinModule = require("is-builtin-module")
+const { isBuiltin } = require("node:module")
 
 /**
  * Extend traceMap.modules with `node:` prefixed modules
@@ -14,9 +14,7 @@ module.exports = function extendTraceMapWithNodePrefix(modules) {
         ...Object.fromEntries(
             Object.entries(modules)
                 .map(([name, value]) => [`node:${name}`, value])
-                .filter(([name]) =>
-                    isBuiltinModule(/** @type {string} */ (name))
-                )
+                .filter(([name]) => isBuiltin(/** @type {string} */ (name)))
         ),
     }
     return ret

--- a/lib/util/import-target.js
+++ b/lib/util/import-target.js
@@ -5,7 +5,7 @@
 "use strict"
 
 const { resolve } = require("path")
-const isBuiltinModule = require("is-builtin-module")
+const { isBuiltin } = require("node:module")
 const resolver = require("enhanced-resolve")
 
 const isTypescript = require("./is-typescript")
@@ -152,7 +152,7 @@ module.exports = class ImportTarget {
             return "absolute"
         }
 
-        if (isBuiltinModule(this.name)) {
+        if (isBuiltin(this.name)) {
             return "node"
         }
 

--- a/lib/util/visit-import.js
+++ b/lib/util/visit-import.js
@@ -5,7 +5,7 @@
 "use strict"
 
 const path = require("path")
-const isBuiltinModule = require("is-builtin-module")
+const { isBuiltin } = require("node:module")
 const getResolvePaths = require("./get-resolve-paths")
 const getTryExtensions = require("./get-try-extensions")
 const ImportTarget = require("./import-target")
@@ -58,7 +58,7 @@ module.exports = function visitImport(
         }
 
         const name = stripImportPathParams(node.source?.value)
-        if (includeCore === true || isBuiltinModule(name) === false) {
+        if (includeCore === true || isBuiltin(name) === false) {
             targets.push(
                 new ImportTarget(context, node.source, name, options, "import")
             )

--- a/lib/util/visit-require.js
+++ b/lib/util/visit-require.js
@@ -10,7 +10,7 @@ const {
     ReferenceTracker,
     getStringIfConstant,
 } = require("@eslint-community/eslint-utils")
-const isBuiltinModule = require("is-builtin-module")
+const { isBuiltin } = require("node:module")
 const getResolvePaths = require("./get-resolve-paths")
 const getTryExtensions = require("./get-try-extensions")
 const ImportTarget = require("./import-target")
@@ -70,7 +70,7 @@ module.exports = function visitRequire(
                 }
 
                 const name = stripImportPathParams(rawName)
-                if (includeCore || !isBuiltinModule(name)) {
+                if (includeCore || !isBuiltin(name)) {
                     targets.push(
                         new ImportTarget(
                             context,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
         "get-tsconfig": "^4.7.0",
         "globals": "^14.0.0",
         "ignore": "^5.2.4",
-        "is-builtin-module": "^3.2.1",
         "minimatch": "^9.0.0",
         "semver": "^7.5.3"
     },

--- a/tests/lib/rules/no-missing-require.js
+++ b/tests/lib/rules/no-missing-require.js
@@ -38,6 +38,10 @@ ruleTester.run("no-missing-require", rule, {
         },
         {
             filename: fixture("test.js"),
+            code: "require('node:test');",
+        },
+        {
+            filename: fixture("test.js"),
             code: "require('eslint');",
         },
         {


### PR DESCRIPTION
Now we support node `>=18.18.0` we can remove `is-builtin-module` (https://github.com/sindresorhus/is-builtin-module/issues/12)