### PR TITLE
fix(no-unsupported-features/node-builtins): `URL.canParse` is stable

### DIFF
--- a/lib/unsupported-features/node-builtins-modules/url.js
+++ b/lib/unsupported-features/node-builtins-modules/url.js
@@ -12,7 +12,7 @@ const url = {
     urlToHttpOptions: { [READ]: { supported: ["15.7.0", "14.18.0"] } },
     URL: {
         [READ]: { supported: ["7.0.0", "6.13.0"] },
-        canParse: { [READ]: { experimental: ["19.9.0"] } },
+        canParse: { [READ]: { supported: ["19.9.0"] } },
         createObjectURL: { [READ]: { experimental: ["16.7.0"] } },
         revokeObjectURL: { [READ]: { supported: ["19.9.0", "18.17.0"] } },
     },


### PR DESCRIPTION
Closes #243