### PR TITLE
fix: Add supported version to Buffer constructor

### DIFF
--- a/lib/unsupported-features/node-builtins-modules/buffer.js
+++ b/lib/unsupported-features/node-builtins-modules/buffer.js
@@ -23,7 +23,7 @@ const buffer = {
     },
     Buffer: {
         [READ]: { supported: ["0.1.90"] },
-        [CONSTRUCT]: { deprecated: ["6.0.0"] },
+        [CONSTRUCT]: { supported: ["0.1.90"], deprecated: ["6.0.0"] },
         alloc: { [READ]: { supported: ["5.10.0", "4.5.0"] } },
         allocUnsafe: { [READ]: { supported: ["5.10.0", "4.5.0"] } },
         allocUnsafeSlow: { [READ]: { supported: ["5.12.0", "4.5.0"] } },

--- a/tests/lib/rules/no-unsupported-features/node-builtins.js
+++ b/tests/lib/rules/no-unsupported-features/node-builtins.js
@@ -218,6 +218,10 @@ new RuleTester({ languageOptions: { sourceType: "module" } }).run(
                         },
                     ],
                 },
+                {
+                    code: "new Buffer(123)",
+                    options: [{ version: "6.0.0" }],
+                },
             ],
             invalid: [
                 {


### PR DESCRIPTION
fixes #265