### PR TITLE
fix: Allow for misconfigured default exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     },
     "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "enhanced-resolve": "^5.15.0",
+        "enhanced-resolve": "^5.17.0",
         "eslint-plugin-es-x": "^7.5.0",
         "get-tsconfig": "^4.7.0",
         "globals": "^15.0.0",

--- a/tests/lib/rules/no-missing-import.js
+++ b/tests/lib/rules/no-missing-import.js
@@ -124,6 +124,11 @@ ruleTester.run("no-missing-import", rule, {
             code: "import a from './e.jsx';",
         },
 
+        {
+            filename: fixture("test.js"),
+            code: "import 'misconfigured-default';",
+        },
+
         // tryExtensions
         {
             filename: fixture("test.js"),
@@ -350,7 +355,9 @@ ruleTester.run("no-missing-import", rule, {
                         resolveError: [
                             "Package path ./sub.mjs is not exported from package",
                             fixture("node_modules/esm-module"),
-                            `(see exports field in ${fixture("node_modules/esm-module/package.json")})`,
+                            `(see exports field in ${fixture(
+                                "node_modules/esm-module/package.json"
+                            )})`,
                         ].join(" "),
                     },
                 },
@@ -433,20 +440,6 @@ ruleTester.run("no-missing-import", rule, {
             code: "import a from './A.js';",
             errors: cantResolve("./A.js"),
             skip: !isCaseSensitiveFileSystem,
-        },
-
-        {
-            filename: fixture("test.js"),
-            code: "import 'misconfigured-default';",
-            errors: [
-                {
-                    messageId: "notFound",
-                    data: {
-                        name: "misconfigured-default",
-                        resolveError: "Default condition should be last one",
-                    },
-                },
-            ],
         },
 
         // import()


### PR DESCRIPTION
fixes #242

This simply adds a test to show that incorrectly configured exports don't get classed as "missing"