### PR TITLE
feat(hashbang): Fix undefined path passed with eslint version < 8.40.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,6 +39,9 @@ jobs:
             node: "18.18.0"
             eslint: "8.x"
           - os: ubuntu-latest
+            node: "18.18.0"
+            eslint: "8.39.0"
+          - os: ubuntu-latest
             node: "20.9.0"
             eslint: "8.x"
           - os: ubuntu-latest

--- a/lib/rules/hashbang.js
+++ b/lib/rules/hashbang.js
@@ -46,11 +46,12 @@ function isNodeShebang(shebang, executableName) {
 }
 
 /**
+ * @param {string} filePath
  * @param {import('eslint').Rule.RuleContext} context The rule context.
  * @returns {string}
  */
-function getExpectedExecutableName(context) {
-    const extension = path.extname(context.filename)
+function getExpectedExecutableName(filePath, context) {
+    const extension = path.extname(filePath)
     /** @type {{ executableMap: Record<string, string> }} */
     const { executableMap = {} } = context.options?.[0] ?? {}
 
@@ -166,7 +167,7 @@ module.exports = {
         const needsShebang =
             isExecutable.ignored === true ||
             isBinFile(convertedAbsolutePath, packageJson?.bin, packageDirectory)
-        const executableName = getExpectedExecutableName(context)
+        const executableName = getExpectedExecutableName(filePath, context)
         const info = getShebangInfo(sourceCode)
 
         return {


### PR DESCRIPTION
While using eslint version < 8.40.0 getting the following error.
`TypeError [ERR_INVALID_ARG_TYPE]: Error while loading rule 'n/hashbang': The "path" argument must be of type string. Received undefined`