### PR TITLE
Use up to date `googleapis/release-please-action` action name

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           config-file: .github/release-please/config.json


### PR DESCRIPTION
https://github.com/google-github-actions/release-please-action says:

> [DEPRECATED] Release Please Action - please use https://github.com/googleapis/release-please-action