### PR TITLE
no-unpublished-imports: Add note on private packages

### DIFF
--- a/docs/rules/no-unpublished-import.md
+++ b/docs/rules/no-unpublished-import.md
@@ -18,6 +18,9 @@ Then this rule warns `import` declarations in \*published\* files if the `import
 > This intends to prevent "Module Not Found" error after `npm publish`.\
 > 💡 If you want to import `devDependencies`, please write `.npmignore` or `"files"` field of `package.json`.
 
+> Note: This rule does not apply to private projects.  
+> To ensure that you don't use `devDependencies` in your application logic, remove `"private": true` from your `package.json` file.
+
 ### Options
 
 ```json


### PR DESCRIPTION
Adds a note that the rule `no-unpublished-imports` is disabled for private packages.

It took me waaay too long to figure out why those issues stopped being reported after upgrading from `eslint-plugin-node` to `eslint-plugin-n`.

