### PR TITLE
fix: `mixed-esm-and-cjs` should only add the deviating type aside from base

### DIFF
--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -26,3 +26,5 @@ module.exports.eslintrc = {
 }
 
 module.exports.flat = recommendedConfig.flat
+
+module.exports.isModule = isModule

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,9 +75,10 @@ const plugin = {
         "flat/recommended-script": { ...cjsConfig.flat },
         "flat/recommended": { ...recommendedConfig.flat },
         "flat/mixed-esm-and-cjs": [
-            { files: ["**/*.js"], ...recommendedConfig.flat },
-            { files: ["**/*.mjs"], ...esmConfig.flat },
-            { files: ["**/*.cjs"], ...cjsConfig.flat },
+            { ...recommendedConfig.flat },
+            recommendedConfig.isModule
+                ? { files: ["**/*.cjs"], ...cjsConfig.flat }
+                : { files: ["**/*.mjs"], ...esmConfig.flat },
         ],
     },
 }


### PR DESCRIPTION
This avoids specifying `**/*.js` and makes the base apply to all files that the main config at large is matching, with only deviating type added for either `**/.mjs` or `**/*.cjs`

This ensures that the rules still match eg. `*.ts`, `*.jsx` etc if the main config does