### PR TITLE
feat: add `name` to flat configs (for tooling)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,13 +71,34 @@ const plugin = {
         "recommended-module": { plugins: ["n"], ...esmConfig.eslintrc },
         "recommended-script": { plugins: ["n"], ...cjsConfig.eslintrc },
         recommended: { plugins: ["n"], ...recommendedConfig.eslintrc },
-        "flat/recommended-module": { ...esmConfig.flat },
-        "flat/recommended-script": { ...cjsConfig.flat },
-        "flat/recommended": { ...recommendedConfig.flat },
+        "flat/recommended-module": {
+            ...esmConfig.flat,
+            name: "n/flat/recommended-module",
+        },
+        "flat/recommended-script": {
+            ...cjsConfig.flat,
+            name: "n/flat/recommended-script",
+        },
+        "flat/recommended": {
+            ...recommendedConfig.flat,
+            name: "n/flat/recommended",
+        },
         "flat/mixed-esm-and-cjs": [
-            { files: ["**/*.js"], ...recommendedConfig.flat },
-            { files: ["**/*.mjs"], ...esmConfig.flat },
-            { files: ["**/*.cjs"], ...cjsConfig.flat },
+            {
+                files: ["**/*.js"],
+                ...recommendedConfig.flat,
+                name: "n/flat/mixed-esm-and-cjs/js",
+            },
+            {
+                files: ["**/*.mjs"],
+                ...esmConfig.flat,
+                name: "n/flat/mixed-esm-and-cjs/mjs",
+            },
+            {
+                files: ["**/*.cjs"],
+                ...cjsConfig.flat,
+                name: "n/flat/mixed-esm-and-cjs/cjs",
+            },
         ],
     },
 }


### PR DESCRIPTION
ESLint [recommends](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-naming-conventions) a name for flat configs.

Tools like https://github.com/eslint/config-inspector can use this to indicate the source of rules.

I did not add it to the older, non-flat configs because it will err there.