### PR TITLE
fix: Revert ts version (5.5 -> 5.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "rimraf": "^5.0.7",
         "ts-ignore-import": "^4.0.1",
         "type-fest": "^4.21.0",
-        "typescript": "^5.5.3"
+        "typescript": "~5.4"
     },
     "scripts": {
         "build": "node scripts/update",


### PR DESCRIPTION
Typescript 5.5:
![image](https://github.com/user-attachments/assets/733938a3-79be-44a5-ae69-ec7cbd373c22)

Typescript 5.4:
![image](https://github.com/user-attachments/assets/475fe5ed-f19d-42c9-8120-4e04869befb0)
