### PR TITLE
fix: Duplex.from is supported in 16.8.0

### DIFF
--- a/lib/unsupported-features/node-builtins-modules/stream.js
+++ b/lib/unsupported-features/node-builtins-modules/stream.js
@@ -23,7 +23,7 @@ const Writable = {
 /** @type {import('../types.js').SupportVersionTraceMap} */
 const Duplex = {
     [READ]: { supported: ["0.9.4"] },
-    from: { [READ]: { experimental: ["16.8.0"] } },
+    from: { [READ]: { supported: ["16.8.0"] } },
     fromWeb: { [READ]: { experimental: ["17.0.0"] } },
     toWeb: { [READ]: { experimental: ["17.0.0"] } },
 }


### PR DESCRIPTION
Fix #324