### PR TITLE
feat(no-missing-import): Add `ignoreTypeImport` options

### DIFF
--- a/docs/rules/no-missing-import.md
+++ b/docs/rules/no-missing-import.md
@@ -62,6 +62,26 @@ Please see the shared settings documentation for more information.
 This can be configured in the rule options or as a shared setting [`settings.typescriptExtensionMap`](../shared-settings.md#typescriptextensionmap).
 Please see the shared settings documentation for more information.
 
+### ignoreTypeImport
+
+If using typescript, you may want to ignore type imports.
+
+```json
+{
+    "rules": {
+        "n/no-missing-import": ["error", {
+            "ignoreTypeImport": true
+        }]
+    }
+}
+```
+
+In this way, the following code will not be reported:
+
+```ts
+import type { TypeOnly } from "@types/only-types";
+```
+
 ## 🔎 Implementation
 
 - [Rule source](../../lib/rules/no-missing-import.js)

--- a/lib/rules/no-missing-import.js
+++ b/lib/rules/no-missing-import.js
@@ -30,6 +30,7 @@ module.exports = {
                     allowModules: getAllowModules.schema,
                     resolvePaths: getResolvePaths.schema,
                     tryExtensions: getTryExtensions.schema,
+                    ignoreTypeImport: { type: "boolean", default: false },
                     tsconfigPath: getTSConfig.schema,
                     typescriptExtensionMap: getTypescriptExtensionMap.schema,
                 },
@@ -39,12 +40,15 @@ module.exports = {
         messages,
     },
     create(context) {
+        const options = context.options[0] ?? {}
+        const ignoreTypeImport = options.ignoreTypeImport ?? false
+
         const filePath = context.filename ?? context.getFilename()
         if (filePath === "<input>") {
             return {}
         }
 
-        return visitImport(context, {}, targets => {
+        return visitImport(context, { ignoreTypeImport }, targets => {
             checkExistence(context, targets)
         })
     },

--- a/tests/lib/rules/no-missing-import.js
+++ b/tests/lib/rules/no-missing-import.js
@@ -342,6 +342,14 @@ ruleTester.run("no-missing-import", rule, {
             code: "import isIp from '#is-ip';",
         },
 
+        // ignoreTypeImport
+        {
+            filename: fixture("test.ts"),
+            code: "import type missing from '@type/this-does-not-exists';",
+            languageOptions: { parser: require("@typescript-eslint/parser") },
+            options: [{ ignoreTypeImport: true }],
+        },
+
         // import()
         ...(DynamicImportSupported
             ? [


### PR DESCRIPTION
Adds the ability to ignore type imports on `no-missing-import`

Closes #286