### PR TITLE
feat(no-process-env): Allow users to exclude specific variables

### DIFF
--- a/docs/rules/no-process-env.md
+++ b/docs/rules/no-process-env.md
@@ -30,6 +30,22 @@ if(config.env === "development") {
 }
 ```
 
+### Options
+
+```json
+{
+    "rules": {
+        "n/no-process-env": ["error", {
+            "allowedVariables": ["NODE_ENV"]
+        }]
+    }
+}
+```
+
+#### allowedVariables
+
+Sometimes you need to allow specific environment variables, this option allows you to exclude specific variables from triggering a linting error.
+
 ## 🔎 Implementation
 
 - [Rule source](../../lib/rules/no-process-env.js)

--- a/lib/rules/no-process-env.js
+++ b/lib/rules/no-process-env.js
@@ -20,6 +20,19 @@ const querySelector = [
     `[property.value="env"]`,
 ]
 
+/**
+ * @param {unknown} node  [description]
+ * @returns {node is import('estree').MemberExpression}
+ */
+function isMemberExpresion(node) {
+    return (
+        node != null &&
+        typeof node === "object" &&
+        "type" in node &&
+        node.type === "MemberExpression"
+    )
+}
+
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
@@ -30,16 +43,48 @@ module.exports = {
             url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-process-env.md",
         },
         fixable: null,
-        schema: [],
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    allowedVariables: {
+                        type: "array",
+                        items: { type: "string" },
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
         messages: {
             unexpectedProcessEnv: "Unexpected use of process.env.",
         },
     },
 
     create(context) {
+        const options = context.options[0] ?? {}
+        /** @type {string[]} */
+        const allowedVariables = options.allowedVariables ?? []
         return {
             /** @param {import('estree').MemberExpression} node */
             [querySelector.join("")](node) {
+                if (
+                    "parent" in node &&
+                    isMemberExpresion(node.parent) &&
+                    node.parent.property != null
+                ) {
+                    const child = node.parent.property
+                    if (
+                        (child.type === "Identifier" &&
+                            node.parent.computed === false &&
+                            allowedVariables.includes(child.name)) ||
+                        (child.type === "Literal" &&
+                            typeof child.value === "string" &&
+                            node.parent.computed === true &&
+                            allowedVariables.includes(child.value))
+                    ) {
+                        return
+                    }
+                }
                 context.report({ node, messageId: "unexpectedProcessEnv" })
             },
         }

--- a/lib/rules/no-process-env.js
+++ b/lib/rules/no-process-env.js
@@ -13,6 +13,11 @@ const querySelector = [
     `[computed!=true]`,
     `[object.name="process"]`,
     `[property.name="env"]`,
+    `,`,
+    `MemberExpression`,
+    `[computed=true]`,
+    `[object.name="process"]`,
+    `[property.value="env"]`,
 ]
 
 /** @type {import('eslint').Rule.RuleModule} */

--- a/tests/lib/rules/no-process-env.js
+++ b/tests/lib/rules/no-process-env.js
@@ -13,6 +13,26 @@ new RuleTester().run("no-process-env", rule, {
         "process[env]",
         "process.nextTick",
         "process.execArgv",
+
+        // allowedVariables
+        {
+            code: "process.env.NODE_ENV",
+            options: [{ allowedVariables: ["NODE_ENV"] }],
+        },
+        {
+            code: "process.env['NODE_ENV']",
+            options: [{ allowedVariables: ["NODE_ENV"] }],
+        },
+        {
+            code: "process['env'].NODE_ENV",
+            options: [{ allowedVariables: ["NODE_ENV"] }],
+        },
+        {
+            code: "process['env']['NODE_ENV']",
+            options: [{ allowedVariables: ["NODE_ENV"] }],
+        },
+        // "process.env",
+        // "process.env[NODE_ENV]",
     ],
 
     invalid: [
@@ -51,6 +71,38 @@ new RuleTester().run("no-process-env", rule, {
                     type: "MemberExpression",
                 },
             ],
+        },
+
+        // allowedVariables
+        {
+            code: "process.env['OTHER_VARIABLE']",
+            options: [{ allowedVariables: ["NODE_ENV"] }],
+            errors: [{ messageId: "unexpectedProcessEnv" }],
+        },
+        {
+            code: "process.env.OTHER_VARIABLE",
+            options: [{ allowedVariables: ["NODE_ENV"] }],
+            errors: [{ messageId: "unexpectedProcessEnv" }],
+        },
+        {
+            code: "process['env']['OTHER_VARIABLE']",
+            options: [{ allowedVariables: ["NODE_ENV"] }],
+            errors: [{ messageId: "unexpectedProcessEnv" }],
+        },
+        {
+            code: "process['env'].OTHER_VARIABLE",
+            options: [{ allowedVariables: ["NODE_ENV"] }],
+            errors: [{ messageId: "unexpectedProcessEnv" }],
+        },
+        {
+            code: "process.env[NODE_ENV]",
+            options: [{ allowedVariables: ["NODE_ENV"] }],
+            errors: [{ messageId: "unexpectedProcessEnv" }],
+        },
+        {
+            code: "process['env'][NODE_ENV]",
+            options: [{ allowedVariables: ["NODE_ENV"] }],
+            errors: [{ messageId: "unexpectedProcessEnv" }],
         },
     ],
 })

--- a/tests/lib/rules/no-process-env.js
+++ b/tests/lib/rules/no-process-env.js
@@ -31,8 +31,6 @@ new RuleTester().run("no-process-env", rule, {
             code: "process['env']['NODE_ENV']",
             options: [{ allowedVariables: ["NODE_ENV"] }],
         },
-        // "process.env",
-        // "process.env[NODE_ENV]",
     ],
 
     invalid: [

--- a/tests/lib/rules/no-process-env.js
+++ b/tests/lib/rules/no-process-env.js
@@ -26,6 +26,15 @@ new RuleTester().run("no-process-env", rule, {
             ],
         },
         {
+            code: "process['env']",
+            errors: [
+                {
+                    messageId: "unexpectedProcessEnv",
+                    type: "MemberExpression",
+                },
+            ],
+        },
+        {
             code: "process.env.ENV",
             errors: [
                 {


### PR DESCRIPTION
This allows users to exclude specific variables from `no-process-env` using the `allowedVariables` string array.