### PR TITLE
fix(no-missing-import): Ignore node builtins in package.json `imports`

### DIFF
--- a/lib/util/import-target.js
+++ b/lib/util/import-target.js
@@ -8,9 +8,16 @@ const { resolve } = require("path")
 const { isBuiltin } = require("node:module")
 const resolver = require("enhanced-resolve")
 
+const {
+    NodeBuiltinModules,
+} = require("../unsupported-features/node-builtins.js")
 const isTypescript = require("./is-typescript")
 const { getTSConfigForContext } = require("./get-tsconfig.js")
 const getTypescriptExtensionMap = require("./get-typescript-extension-map")
+
+const nodeBuiltinFallback = Object.keys(NodeBuiltinModules).map(
+    name => /** @type {const} */ ({ name, alias: false })
+)
 
 /**
  * @overload
@@ -302,6 +309,8 @@ module.exports = class ImportTarget {
 
             extensionAlias,
             alias,
+
+            fallback: nodeBuiltinFallback,
         }
 
         const requireResolve = resolver.create.sync(this.resolverConfig)

--- a/tests/fixtures/no-missing/issue-285/package.json
+++ b/tests/fixtures/no-missing/issue-285/package.json
@@ -1,0 +1,8 @@
+{
+    "imports": {
+        "#is-ip": {
+            "node": "net",
+            "browser": "is-ip"
+        }
+    }
+}

--- a/tests/lib/rules/no-missing-import.js
+++ b/tests/lib/rules/no-missing-import.js
@@ -328,6 +328,12 @@ ruleTester.run("no-missing-import", rule, {
             code: "import plugin from 'eslint-plugin-n';",
         },
 
+        // imports alias
+        {
+            filename: fixture("issue-285/test.js"),
+            code: "import isIp from '#is-ip';",
+        },
+
         // import()
         ...(DynamicImportSupported
             ? [


### PR DESCRIPTION
This covers over `enhanced-resolve`'s behaviour of throwing unresolved modules, as it cannot resolve builtin node modules.

This is done by adding a load of aliases that are effectivly: `{ name: moduleName, alias: false }` meaning that enhanced resolve does not throw.