### PR TITLE
fix(no-deprecated-api): dedeprecate `process.nextTick`

### DIFF
--- a/lib/rules/no-deprecated-api.js
+++ b/lib/rules/no-deprecated-api.js
@@ -330,12 +330,6 @@ const rawModules = {
                 },
             },
         },
-        nextTick: {
-            [READ]: {
-                since: "22.7.0",
-                replacedBy: "'queueMicrotask()'",
-            },
-        },
     },
     punycode: {
         [READ]: {


### PR DESCRIPTION
I've recently noticed that this module is starting to tag `process.nextTick()` as deprecated. But it's not. Essentially it's close to impossible to stop using for old code, because it will alter the order of callbacks being fired.

Here is the full discussion: https://github.com/nodejs/node/pull/51280. Note that Node.js still uses it _everywhere_, because it's not possible to replace it without breaking a lot of people.

![image](https://github.com/user-attachments/assets/1a259404-c3e8-464d-8509-8ff22ecf4d53)
