### PR TITLE
fix(no-deprecated-api): dedeprecate `process.nextTick`

### DIFF
--- a/lib/rules/no-deprecated-api.js
+++ b/lib/rules/no-deprecated-api.js
@@ -330,12 +330,6 @@ const rawModules = {
                 },
             },
         },
-        nextTick: {
-            [READ]: {
-                since: "22.7.0",
-                replacedBy: "'queueMicrotask()'",
-            },
-        },
     },
     punycode: {
         [READ]: {


### PR DESCRIPTION
Fixes #350