### PR TITLE
feat(no-sync): Add `ignores` option

### DIFF
--- a/docs/rules/no-sync.md
+++ b/docs/rules/no-sync.md
@@ -10,6 +10,8 @@ This rule is aimed at preventing synchronous methods from being called in Node.j
 
 ### Options
 
+#### allowAtRootLevel
+
 This rule has an optional object option `{ allowAtRootLevel: <boolean> }`, which determines whether synchronous methods should be allowed at the top level of a file, outside of any functions. This option defaults to `false`.
 
 Examples of **incorrect** code for this rule with the default `{ allowAtRootLevel: false }` option:
@@ -54,6 +56,26 @@ Examples of **correct** code for this rule with the `{ allowAtRootLevel: true }`
 /*eslint n/no-sync: ["error", { allowAtRootLevel: true }]*/
 
 fs.readFileSync(somePath).toString();
+```
+
+#### ignores
+
+You can `ignore` specific function names using this option.
+
+Examples of **incorrect** code for this rule with the `{ ignores: ['readFileSync'] }` option:
+
+```js
+/*eslint n/no-sync: ["error", { ignores: ['readFileSync'] }] */
+
+fs.readdirSync(somePath);
+```
+
+Examples of **correct** code for this rule with the `{ ignores: ['readFileSync'] }` option:
+
+```js
+/*eslint n/no-sync: ["error", { ignores: ['readFileSync'] }] */
+
+fs.readFileSync(somePath);
 ```
 
 ## 🔎 Implementation

--- a/lib/rules/no-sync.js
+++ b/lib/rules/no-sync.js
@@ -4,23 +4,13 @@
  */
 "use strict"
 
-const allowedAtRootLevelSelector = [
+const selectors = [
     // fs.readFileSync()
-    ":function MemberExpression > Identifier[name=/Sync$/]",
     // readFileSync.call(null, 'path')
-    ":function MemberExpression > Identifier[name=/Sync$/]",
+    "CallExpression > MemberExpression.callee Identifier[name=/Sync$/]",
     // readFileSync()
-    ":function :not(MemberExpression) > Identifier[name=/Sync$/]",
-].join(",")
-
-const disallowedAtRootLevelSelector = [
-    // fs.readFileSync()
-    "MemberExpression > Identifier[name=/Sync$/]",
-    // readFileSync.call(null, 'path')
-    "MemberExpression > Identifier[name=/Sync$/]",
-    // readFileSync()
-    ":not(MemberExpression) > Identifier[name=/Sync$/]",
-].join(",")
+    "CallExpression > Identifier[name=/Sync$/]",
+]
 
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
@@ -50,17 +40,17 @@ module.exports = {
     },
 
     create(context) {
-        const selector = context.options[0]?.allowAtRootLevel
-            ? allowedAtRootLevelSelector
-            : disallowedAtRootLevelSelector
+        const options = context.options[0] ?? {}
 
+        const selector = options.allowAtRootLevel
+            ? selectors.map(selector => `:function ${selector}`)
+            : selectors
         return {
             /**
-             * [node description]
              * @param {import('estree').Identifier & {parent: import('estree').Node}} node
              * @returns {void}
              */
-            [selector](node) {
+            [selector.join(",")](node) {
                 context.report({
                     node: node.parent,
                     messageId: "noSync",

--- a/lib/rules/no-sync.js
+++ b/lib/rules/no-sync.js
@@ -30,6 +30,11 @@ module.exports = {
                         type: "boolean",
                         default: false,
                     },
+                    ignores: {
+                        type: "array",
+                        items: { type: "string" },
+                        default: [],
+                    },
                 },
                 additionalProperties: false,
             },
@@ -41,6 +46,7 @@ module.exports = {
 
     create(context) {
         const options = context.options[0] ?? {}
+        const ignores = options.ignores ?? []
 
         const selector = options.allowAtRootLevel
             ? selectors.map(selector => `:function ${selector}`)
@@ -51,6 +57,10 @@ module.exports = {
              * @returns {void}
              */
             [selector.join(",")](node) {
+                if (ignores.includes(node.name)) {
+                    return
+                }
+
                 context.report({
                     node: node.parent,
                     messageId: "noSync",

--- a/tests/lib/rules/no-sync.js
+++ b/tests/lib/rules/no-sync.js
@@ -22,6 +22,11 @@ new RuleTester().run("no-sync", rule, {
             code: "if (true) {fooSync();}",
             options: [{ allowAtRootLevel: true }],
         },
+        // ignores
+        {
+            code: "fooSync();",
+            options: [{ ignores: ["fooSync"] }],
+        },
     ],
     invalid: [
         {
@@ -109,6 +114,23 @@ new RuleTester().run("no-sync", rule, {
         {
             code: "var a = function someFunction() {fs.fooSync();}",
             options: [{ allowAtRootLevel: true }],
+            errors: [
+                {
+                    messageId: "noSync",
+                    data: { propertyName: "fooSync" },
+                    type: "MemberExpression",
+                },
+            ],
+        },
+        // ignores
+        {
+            code: "() => {fs.fooSync();}",
+            options: [
+                {
+                    allowAtRootLevel: true,
+                    ignores: ["barSync"],
+                },
+            ],
             errors: [
                 {
                     messageId: "noSync",

--- a/tests/lib/rules/no-sync.js
+++ b/tests/lib/rules/no-sync.js
@@ -10,14 +10,10 @@ const rule = require("../../../lib/rules/no-sync")
 new RuleTester().run("no-sync", rule, {
     valid: [
         "var foo = fs.foo.foo();",
-        {
-            code: "var foo = fs.fooSync;",
-            options: [{ allowAtRootLevel: true }],
-        },
-        {
-            code: "var foo = fooSync;",
-            options: [{ allowAtRootLevel: true }],
-        },
+        // Allow non-function called to be ignored
+        "fs.fooSync;",
+        "fooSync;",
+        "() => fooSync;",
         {
             code: "if (true) {fs.fooSync();}",
             options: [{ allowAtRootLevel: true }],
@@ -81,16 +77,6 @@ new RuleTester().run("no-sync", rule, {
         },
         {
             code: "if (true) {fs.fooSync();}",
-            errors: [
-                {
-                    messageId: "noSync",
-                    data: { propertyName: "fooSync" },
-                    type: "MemberExpression",
-                },
-            ],
-        },
-        {
-            code: "var foo = fs.fooSync;",
             errors: [
                 {
                     messageId: "noSync",


### PR DESCRIPTION
I am still on the fence about #354

As one part of me thinks that we should be specific to the node apis only.
The other part of me thinks that we should make all possibly sync function calls as bad in the node environment :thinking:

---

I am slowly leaning towards using the [`ReferenceTracker`](https://eslint-community.github.io/eslint-utils/api/scope-utils.html#referencetracker-class) from [eslint-utils](https://eslint-community.github.io/eslint-utils) to only mark call expressions from node apis.