### PR TITLE
chore: revert ts ~v5.4 & test typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@
 .vscode
 .idea/
 
-types/

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "rimraf": "^5.0.10",
         "ts-ignore-import": "^4.0.1",
         "type-fest": "^4.26.1",
-        "typescript": "~5.6"
+        "typescript": "~5.4"
     },
     "scripts": {
         "build": "node scripts/update",
@@ -64,13 +64,12 @@
         "lint:js": "eslint .",
         "new": "node scripts/new-rule",
         "postversion": "git push && git push --tags",
-        "prepack": "tsc --emitDeclarationOnly && ts-ignore-import 'types/**/*.d.ts' --allow=@eslint-community/eslint-utils --allow=semver --allow=get-tsconfig",
         "prepare": "husky",
         "preversion": "npm test",
         "test": "run-p lint:* test:types test:tests",
         "test:mocha": "_mocha  --reporter progress --timeout 4000",
         "test:tests": "npm run test:mocha \"tests/lib/**/*.js\"",
-        "test:types": "tsc --noEmit --emitDeclarationOnly false",
+        "test:types": "tsc --emitDeclarationOnly false",
         "update:eslint-docs": "eslint-doc-generator",
         "version": "npm run -s build && eslint lib/rules --fix && git add .",
         "watch": "npm run test:_mocha -- --watch --growl"

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,0 +1,11 @@
+import pkg from "../"
+
+pkg.rules;
+pkg.configs.recommended;
+pkg.configs["recommended-module"];
+pkg.configs["recommended-script"];
+
+pkg.configs["flat/recommended"];
+pkg.configs["flat/recommended-module"];
+pkg.configs["flat/recommended-script"];
+pkg.configs["flat/mixed-esm-and-cjs"];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,11 +8,12 @@
         "allowJs": true,
         "checkJs": true,
 
+        "noEmit": true,
         "declaration": true,
         "emitDeclarationOnly": true,
         "declarationDir": "./types",
 
-        "allowSyntheticDefaultImports": false,
+        "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,
         "resolveJsonModule": true,
 
@@ -21,5 +22,5 @@
         "skipLibCheck": false
     },
     "include": ["./lib/eslint-utils.d.ts"],
-    "files": ["./lib/index.js"]
+    "files": ["./lib/index.js", "./tests/types.test.ts"]
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,25 @@
+export = plugin;
+/**
+ * @typedef {{
+     'recommended-module': import('eslint').ESLint.ConfigData;
+     'recommended-script': import('eslint').ESLint.ConfigData;
+     'recommended': import('eslint').ESLint.ConfigData;
+     'flat/recommended-module': import('eslint').Linter.FlatConfig;
+     'flat/recommended-script': import('eslint').Linter.FlatConfig;
+     'flat/recommended': import('eslint').Linter.FlatConfig;
+     'flat/mixed-esm-and-cjs': import('eslint').Linter.FlatConfig[];
+ }} Configs
+ */
+/** @type {import('eslint').ESLint.Plugin & { configs: Configs }} */
+declare const plugin: import('eslint').ESLint.Plugin & {
+    configs: Configs;
+};
+type Configs = {
+    'recommended-module': import('eslint').ESLint.ConfigData;
+    'recommended-script': import('eslint').ESLint.ConfigData;
+    'recommended': import('eslint').ESLint.ConfigData;
+    'flat/recommended-module': import('eslint').Linter.FlatConfig;
+    'flat/recommended-script': import('eslint').Linter.FlatConfig;
+    'flat/recommended': import('eslint').Linter.FlatConfig;
+    'flat/mixed-esm-and-cjs': import('eslint').Linter.FlatConfig[];
+};


### PR DESCRIPTION
1. unignore `types/index.d.ts`
2. remove npm script `prepack` - it's no longer auto-generated
3. add a test for the typings