### PR TITLE
refactor: Improve typescript types and strictness

### DIFF
--- a/lib/configs/_commons.js
+++ b/lib/configs/_commons.js
@@ -1,6 +1,9 @@
 "use strict"
 
-module.exports.commonRules = /** @type {const} */ ({
+/**
+ * @type {import('eslint').Linter.RulesRecord}
+ */
+module.exports.commonRules = {
     "n/no-deprecated-api": "error",
     "n/no-extraneous-import": "error",
     "n/no-extraneous-require": "error",
@@ -16,4 +19,4 @@ module.exports.commonRules = /** @type {const} */ ({
     "n/no-unsupported-features/node-builtins": "error",
     "n/process-exit-as-throw": "error",
     "n/hashbang": "error",
-})
+}

--- a/lib/eslint-utils.d.ts
+++ b/lib/eslint-utils.d.ts
@@ -1,12 +1,9 @@
 declare module "eslint-plugin-es-x" {
-    // @ts-ignore
     export const rules: NonNullable<import('eslint').ESLint.Plugin["rules"]>;
 }
 
 declare module "@eslint-community/eslint-utils" {
-    // @ts-ignore
     import * as estree from 'estree';
-    // @ts-ignore
     import * as eslint from 'eslint';
 
     type Node = estree.Node | estree.Expression;

--- a/lib/eslint-utils.d.ts
+++ b/lib/eslint-utils.d.ts
@@ -39,7 +39,7 @@ declare module "@eslint-community/eslint-utils" {
         [READ]?: Info;
         [CALL]?: Info;
         [CONSTRUCT]?: Info;
-        [key: string]: TraceMap<Info>;
+        [key: string]: TraceMap<Info> | undefined;
     }
     type RichNode = eslint.Rule.Node | Node;
     type Reference<Info extends unknown> = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,25 +5,13 @@ const esmConfig = require("./configs/recommended-module")
 const cjsConfig = require("./configs/recommended-script")
 const recommendedConfig = require("./configs/recommended")
 
-/**
- * @typedef {{
-     'recommended-module': import('eslint').ESLint.ConfigData;
-     'recommended-script': import('eslint').ESLint.ConfigData;
-     'recommended': import('eslint').ESLint.ConfigData;
-     'flat/recommended-module': import('eslint').Linter.FlatConfig;
-     'flat/recommended-script': import('eslint').Linter.FlatConfig;
-     'flat/recommended': import('eslint').Linter.FlatConfig;
-     'flat/mixed-esm-and-cjs': import('eslint').Linter.FlatConfig[];
- }} Configs
- */
-
-/** @type {import('eslint').ESLint.Plugin & { configs: Configs }} */
-const plugin = {
+/** @type {import('eslint').ESLint.Plugin} */
+const base = {
     meta: {
         name: pkg.name,
         version: pkg.version,
     },
-    rules: /** @type {Record<string, import('eslint').Rule.RuleModule>} */ ({
+    rules: {
         "callback-return": require("./rules/callback-return"),
         "exports-style": require("./rules/exports-style"),
         "file-extension-in-import": require("./rules/file-extension-in-import"),
@@ -66,28 +54,38 @@ const plugin = {
         // Deprecated rules.
         "no-hide-core-modules": require("./rules/no-hide-core-modules"),
         shebang: require("./rules/shebang"),
-    }),
-    configs: {
-        "recommended-module": { plugins: ["n"], ...esmConfig.eslintrc },
-        "recommended-script": { plugins: ["n"], ...cjsConfig.eslintrc },
-        recommended: { plugins: ["n"], ...recommendedConfig.eslintrc },
-        "flat/recommended-module": { ...esmConfig.flat },
-        "flat/recommended-script": { ...cjsConfig.flat },
-        "flat/recommended": { ...recommendedConfig.flat },
-        "flat/mixed-esm-and-cjs": [
-            { files: ["**/*.js"], ...recommendedConfig.flat },
-            { files: ["**/*.mjs"], ...esmConfig.flat },
-            { files: ["**/*.cjs"], ...cjsConfig.flat },
-        ],
     },
 }
+/**
+ * @typedef {{
+ *     'recommended-module': import('eslint').ESLint.ConfigData;
+ *     'recommended-script': import('eslint').ESLint.ConfigData;
+ *     'recommended': import('eslint').ESLint.ConfigData;
+ *     'flat/recommended-module': import('eslint').Linter.FlatConfig;
+ *     'flat/recommended-script': import('eslint').Linter.FlatConfig;
+ *     'flat/recommended': import('eslint').Linter.FlatConfig;
+ *     'flat/mixed-esm-and-cjs': import('eslint').Linter.FlatConfig[];
+ * }} Configs
+ */
 
-plugin.configs["flat/recommended-module"].plugins = { n: plugin }
-plugin.configs["flat/recommended-script"].plugins = { n: plugin }
-plugin.configs["flat/recommended"].plugins = { n: plugin }
-
-for (const config of plugin.configs["flat/mixed-esm-and-cjs"]) {
-    config.plugins = { n: plugin }
+/** @type {Configs} */
+const configs = {
+    "recommended-module": { plugins: ["n"], ...esmConfig.eslintrc },
+    "recommended-script": { plugins: ["n"], ...cjsConfig.eslintrc },
+    recommended: { plugins: ["n"], ...recommendedConfig.eslintrc },
+    "flat/recommended-module": { plugins: { n: base }, ...esmConfig.flat },
+    "flat/recommended-script": { plugins: { n: base }, ...cjsConfig.flat },
+    "flat/recommended": { plugins: { n: base }, ...recommendedConfig.flat },
+    "flat/mixed-esm-and-cjs": [
+        { files: ["**/*.js"], plugins: { n: base }, ...recommendedConfig.flat },
+        { files: ["**/*.mjs"], plugins: { n: base }, ...esmConfig.flat },
+        { files: ["**/*.cjs"], plugins: { n: base }, ...cjsConfig.flat },
+    ],
 }
 
-module.exports = plugin
+/** @type {import('eslint').ESLint.Plugin & { configs: Configs }} */
+module.exports = {
+    meta: base.meta,
+    rules: base.rules,
+    configs: configs,
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,9 @@ const esmConfig = require("./configs/recommended-module")
 const cjsConfig = require("./configs/recommended-script")
 const recommendedConfig = require("./configs/recommended")
 
-/** @type {import('eslint').ESLint.Plugin} */
+/** @import { ESLint, Linter } from 'eslint' */
+
+/** @type {ESLint.Plugin} */
 const base = {
     meta: {
         name: pkg.name,
@@ -58,13 +60,13 @@ const base = {
 }
 /**
  * @typedef {{
- *     'recommended-module': import('eslint').ESLint.ConfigData;
- *     'recommended-script': import('eslint').ESLint.ConfigData;
- *     'recommended': import('eslint').ESLint.ConfigData;
- *     'flat/recommended-module': import('eslint').Linter.FlatConfig;
- *     'flat/recommended-script': import('eslint').Linter.FlatConfig;
- *     'flat/recommended': import('eslint').Linter.FlatConfig;
- *     'flat/mixed-esm-and-cjs': import('eslint').Linter.FlatConfig[];
+ *     'recommended-module': ESLint.ConfigData;
+ *     'recommended-script': ESLint.ConfigData;
+ *     'recommended': ESLint.ConfigData;
+ *     'flat/recommended-module': Linter.Config;
+ *     'flat/recommended-script': Linter.Config;
+ *     'flat/recommended': Linter.Config;
+ *     'flat/mixed-esm-and-cjs': Linter.Config[];
  * }} Configs
  */
 
@@ -83,7 +85,7 @@ const configs = {
     ],
 }
 
-/** @type {import('eslint').ESLint.Plugin & { configs: Configs }} */
+/** @type {ESLint.Plugin & { configs: Configs }} */
 module.exports = {
     meta: base.meta,
     rules: base.rules,

--- a/lib/rules/callback-return.js
+++ b/lib/rules/callback-return.js
@@ -82,7 +82,7 @@ module.exports = {
         /**
          * Determines whether or not the callback is part of a callback expression.
          * @param {import('eslint').Rule.Node} node The callback node
-         * @param {import('estree').Statement} parentNode The expression node
+         * @param {import('estree').Statement} [parentNode] The expression node
          * @returns {boolean} Whether or not this is part of a callback expression
          */
         function isCallbackExpression(node, parentNode) {
@@ -136,8 +136,7 @@ module.exports = {
                 // block statements are part of functions and most if statements
                 if (closestBlock?.type === "BlockStatement") {
                     // find the last item in the block
-                    const lastItem =
-                        closestBlock.body[closestBlock.body.length - 1]
+                    const lastItem = closestBlock.body.at(-1)
 
                     // if the callback is the last thing in a block that might be ok
                     if (isCallbackExpression(node, lastItem)) {
@@ -154,13 +153,10 @@ module.exports = {
                     }
 
                     // ending a block with a return is also ok
-                    if (lastItem.type === "ReturnStatement") {
+                    if (lastItem?.type === "ReturnStatement") {
                         // but only if the callback is immediately before
                         if (
-                            isCallbackExpression(
-                                node,
-                                closestBlock.body[closestBlock.body.length - 2]
-                            )
+                            isCallbackExpression(node, closestBlock.body.at(-2))
                         ) {
                             return
                         }

--- a/lib/rules/exports-style.js
+++ b/lib/rules/exports-style.js
@@ -39,7 +39,7 @@ function getStaticPropertyName(node) {
 
         case "TemplateLiteral":
             if (prop.expressions.length === 0 && prop.quasis.length === 1) {
-                return prop.quasis[0].value.cooked
+                return prop.quasis[0]?.value.cooked
             }
             break
 

--- a/lib/rules/exports-style.js
+++ b/lib/rules/exports-style.js
@@ -4,15 +4,13 @@
  */
 "use strict"
 
-/**
- * @typedef {import('estree').Node & { parent?: Node }} Node
- */
+const { hasParentNode } = require("../util/has-parent-node.js")
 
 /*istanbul ignore next */
 /**
  * This function is copied from https://github.com/eslint/eslint/blob/2355f8d0de1d6732605420d15ddd4f1eee3c37b6/lib/ast-utils.js#L648-L684
  *
- * @param {Node} node - The node to get.
+ * @param {import('estree').Node} node - The node to get.
  * @returns {string | null | undefined} The property name if static. Otherwise, null.
  * @private
  */
@@ -44,12 +42,7 @@ function getStaticPropertyName(node) {
             break
 
         case "Identifier":
-            if (
-                !(
-                    /** @type {import('estree').MemberExpression} */ (node)
-                        .computed
-                )
-            ) {
+            if (node.type === "MemberExpression" && node.computed === false) {
                 return prop.name
             }
             break
@@ -63,11 +56,12 @@ function getStaticPropertyName(node) {
 /**
  * Checks whether the given node is assignee or not.
  *
- * @param {Node} node - The node to check.
+ * @param {import('estree').Node} node - The node to check.
  * @returns {boolean} `true` if the node is assignee.
  */
 function isAssignee(node) {
     return (
+        hasParentNode(node) &&
         node.parent?.type === "AssignmentExpression" &&
         node.parent.left === node
     )
@@ -79,15 +73,16 @@ function isAssignee(node) {
  * This is used to distinguish 2 assignees belong to the same assignment.
  * If the node is not an assignee, this returns null.
  *
- * @param {Node} leafNode - The node to get.
- * @returns {Node|null} The top assignment expression node, or null.
+ * @param {import('estree').Node} leafNode - The node to get.
+ * @returns {import('estree').Node | null} The top assignment expression node, or null.
  */
 function getTopAssignment(leafNode) {
     let node = leafNode
 
     // Skip MemberExpressions.
     while (
-        node.parent?.type === "MemberExpression" &&
+        hasParentNode(node) &&
+        node.parent.type === "MemberExpression" &&
         node.parent.object === node
     ) {
         node = node.parent
@@ -99,7 +94,7 @@ function getTopAssignment(leafNode) {
     }
 
     // Find the top.
-    while (node.parent?.type === "AssignmentExpression") {
+    while (hasParentNode(node) && node.parent.type === "AssignmentExpression") {
         node = node.parent
     }
 
@@ -109,35 +104,41 @@ function getTopAssignment(leafNode) {
 /**
  * Gets top assignment nodes of the given node list.
  *
- * @param {Node[]} nodes - The node list to get.
- * @returns {Node[]} Gotten top assignment nodes.
+ * @param {import('estree').Node[]} nodes - The node list to get.
+ * @returns {import('estree').Node[]} Gotten top assignment nodes.
  */
 function createAssignmentList(nodes) {
-    return /** @type {Node[]} */ (nodes.map(getTopAssignment).filter(Boolean))
+    return nodes.map(getTopAssignment).filter(input => input != null)
 }
 
 /**
  * Gets the reference of `module.exports` from the given scope.
  *
  * @param {import('eslint').Scope.Scope} scope - The scope to get.
- * @returns {Node[]} Gotten MemberExpression node list.
+ * @returns {import('estree').Node[]} Gotten MemberExpression node list.
  */
 function getModuleExportsNodes(scope) {
     const variable = scope.set.get("module")
     if (variable == null) {
         return []
     }
-    return variable.references
-        .map(
-            reference =>
-                /** @type {Node & { parent: Node }} */ (reference.identifier)
-                    .parent
-        )
-        .filter(
-            node =>
-                node?.type === "MemberExpression" &&
-                getStaticPropertyName(node) === "exports"
-        )
+
+    /** @type {import('estree').Node[]} */
+    const nodes = []
+
+    for (const reference of variable.references) {
+        if (hasParentNode(reference.identifier) === false) {
+            continue
+        }
+        const node = reference.identifier.parent
+        if (
+            node.type === "MemberExpression" &&
+            getStaticPropertyName(node) === "exports"
+        ) {
+            nodes.push(node)
+        }
+    }
+    return nodes
 }
 
 /**
@@ -156,7 +157,7 @@ function getExportsNodes(scope) {
 }
 
 /**
- * @param {Node} property
+ * @param {import('estree').Node} property
  * @param {import('eslint').SourceCode} sourceCode
  * @returns {string | null}
  */
@@ -210,13 +211,16 @@ function getReplacementForProperty(property, sourceCode) {
 
 /**
  * Check for a top level module.exports = { ... }
- * @param {Node} node
+ * @param {import('estree').Node} node
  * @returns {node is {parent: import('estree').AssignmentExpression & {parent: import('estree').ExpressionStatement, right: import('estree').ObjectExpression}}}
  */
 function isModuleExportsObjectAssignment(node) {
     return (
+        hasParentNode(node) &&
         node.parent?.type === "AssignmentExpression" &&
+        hasParentNode(node.parent) &&
         node.parent?.parent?.type === "ExpressionStatement" &&
+        hasParentNode(node.parent.parent) &&
         node.parent.parent.parent?.type === "Program" &&
         node.parent.right.type === "ObjectExpression"
     )
@@ -224,17 +228,19 @@ function isModuleExportsObjectAssignment(node) {
 
 /**
  * Check for module.exports.foo or module.exports.bar reference or assignment
- * @param {Node} node
+ * @param {import('estree').Node} node
  * @returns {node is import('estree').MemberExpression}
  */
 function isModuleExportsReference(node) {
     return (
-        node.parent?.type === "MemberExpression" && node.parent.object === node
+        hasParentNode(node) &&
+        node.parent?.type === "MemberExpression" &&
+        node.parent.object === node
     )
 }
 
 /**
- * @param {Node} node
+ * @param {import('estree').Node} node
  * @param {import('eslint').SourceCode} sourceCode
  * @param {import('eslint').Rule.RuleFixer} fixer
  * @returns {import('eslint').Rule.Fix | null}
@@ -307,16 +313,17 @@ module.exports = {
          * module.exports = foo
          * ^^^^^^^^^^^^^^^^
          *
-         * @param {Node} node - The node of `exports`/`module.exports`.
-         * @returns {import('estree').SourceLocation} The location info of reports.
+         * @param {import('estree').Node} node - The node of `exports`/`module.exports`.
+         * @returns {import('estree').SourceLocation | undefined} The location info of reports.
          */
         function getLocation(node) {
             const token = sourceCode.getTokenAfter(node)
+            if (node.loc?.start == null || token?.loc?.end == null) {
+                return
+            }
             return {
-                start: /** @type {import('estree').SourceLocation} */ (node.loc)
-                    .start,
-                end: /** @type {import('estree').SourceLocation} */ (token?.loc)
-                    ?.end,
+                start: node.loc?.start,
+                end: token?.loc?.end,
             }
         }
 

--- a/lib/rules/file-extension-in-import.js
+++ b/lib/rules/file-extension-in-import.js
@@ -95,8 +95,11 @@ module.exports = {
                     messageId: "requireExt",
                     data: { ext: expectedExt },
                     fix(fixer) {
-                        const index =
-                            /** @type {[number, number]} */ (node.range)[1] - 1
+                        if (node.range == null) {
+                            return null
+                        }
+
+                        const index = node.range[1] - 1
                         return fixer.insertTextBeforeRange(
                             [index, index],
                             expectedExt
@@ -121,8 +124,11 @@ module.exports = {
 
                 if (otherExtensions.length === 1) {
                     descriptor.fix = fixer => {
+                        if (node.range == null) {
+                            return null
+                        }
+
                         const index = name.lastIndexOf(currentExt)
-                        // @ts-expect-error - Range is defined...
                         const start = node.range[0] + 1 + index
                         const end = start + currentExt.length
                         return fixer.removeRange([start, end])

--- a/lib/rules/file-extension-in-import.js
+++ b/lib/rules/file-extension-in-import.js
@@ -112,26 +112,24 @@ module.exports = {
                 currentExt === expectedExt
             ) {
                 const otherExtensions = getExistingExtensions(filePath)
-
-                context.report({
+                /** @type {import('eslint').Rule.ReportDescriptor} */
+                const descriptor = {
                     node,
                     messageId: "forbidExt",
                     data: { ext: currentExt },
-                    fix:
-                        otherExtensions.length > 1
-                            ? undefined
-                            : fixer => {
-                                  const index = name.lastIndexOf(currentExt)
-                                  const start =
-                                      /** @type {[number, number]} */ (
-                                          node.range
-                                      )[0] +
-                                      1 +
-                                      index
-                                  const end = start + currentExt.length
-                                  return fixer.removeRange([start, end])
-                              },
-                })
+                }
+
+                if (otherExtensions.length === 1) {
+                    descriptor.fix = fixer => {
+                        const index = name.lastIndexOf(currentExt)
+                        // @ts-expect-error - Range is defined...
+                        const start = node.range[0] + 1 + index
+                        const end = start + currentExt.length
+                        return fixer.removeRange([start, end])
+                    }
+                }
+
+                context.report(descriptor)
             }
         }
 

--- a/lib/rules/global-require.js
+++ b/lib/rules/global-require.js
@@ -67,8 +67,8 @@ module.exports = {
                     sourceCode.getScope?.(node) ?? context.getScope() //TODO: remove context.getScope() when dropping support for ESLint < v9
 
                 if (
-                    /** @type {import('estree').Identifier} */ (node.callee)
-                        .name === "require" &&
+                    node.callee.type === "Identifier" &&
+                    node.callee.name === "require" &&
                     !isShadowed(currentScope, node.callee)
                 ) {
                     const isGoodRequire = (

--- a/lib/rules/no-callback-literal.js
+++ b/lib/rules/no-callback-literal.js
@@ -28,14 +28,12 @@ module.exports = {
         return {
             CallExpression(node) {
                 const errorArg = node.arguments[0]
-                const calleeName = /** @type {import('estree').Identifier} */ (
-                    node.callee
-                ).name
 
                 if (
                     errorArg &&
                     !couldBeError(errorArg) &&
-                    callbackNames.includes(calleeName)
+                    node.callee.type === "Identifier" &&
+                    callbackNames.includes(node.callee.name)
                 ) {
                     context.report({
                         node,

--- a/lib/rules/no-callback-literal.js
+++ b/lib/rules/no-callback-literal.js
@@ -49,11 +49,11 @@ module.exports = {
 
 /**
  * Determine if a node has a possiblity to be an Error object
- * @param  {import('estree').Node}  node  ASTNode to check
+ * @param  {import('estree').Node}  [node]  ASTNode to check
  * @returns {boolean}       True if there is a chance it contains an Error obj
  */
 function couldBeError(node) {
-    switch (node.type) {
+    switch (node?.type) {
         case "Identifier":
         case "CallExpression":
         case "NewExpression":

--- a/lib/rules/no-deprecated-api.js
+++ b/lib/rules/no-deprecated-api.js
@@ -686,10 +686,7 @@ const globals = {
             replacedBy: [{ name: "'global'", supported: "0.1.27" }],
         },
     },
-    process:
-        /** @type {import('../unsupported-features/types.js').DeprecatedInfoTraceMap} */ (
-            modules.process
-        ),
+    process: modules.process,
 }
 
 /**
@@ -704,14 +701,14 @@ function toReplaceMessage(replacedBy, version) {
 
     if (Array.isArray(replacedBy)) {
         message = replacedBy
-            .filter(
-                ({ supported }) =>
-                    !version.intersects(
-                        /** @type {import('semver').Range} */ (
-                            getSemverRange(`<${supported}`)
-                        )
-                    )
-            )
+            .filter(({ supported }) => {
+                const range = getSemverRange(`<${supported}`)
+                if (range == null) {
+                    return false
+                }
+
+                return !version.intersects(range)
+            })
             .map(({ name }) => name)
             .join(" or ")
     }
@@ -818,9 +815,6 @@ module.exports = {
 
             context.report({
                 node,
-                loc: /** @type {NonNullable<import('estree').Node["loc"]>} */ (
-                    node.loc
-                ),
                 messageId,
                 data,
             })

--- a/lib/rules/no-deprecated-api.js
+++ b/lib/rules/no-deprecated-api.js
@@ -23,7 +23,7 @@ const unprefixNodeColon = require("../util/unprefix-node-colon")
  * @property {Set<string>} ignoredGlobalItems
  * @property {Set<string>} ignoredModuleItems
  */
-/** @type {import('@eslint-community/eslint-utils').TraceMap<DeprecatedInfo>} */
+/** @type {import('../unsupported-features/types.js').DeprecatedInfoTraceMap} */
 const rawModules = {
     _linklist: {
         [READ]: { since: "5.0.0", replacedBy: null },
@@ -625,6 +625,7 @@ const rawModules = {
 }
 const modules = extendTrackmapWithNodePrefix(rawModules)
 
+/** @type {import('../unsupported-features/types.js').DeprecatedInfoTraceMap} */
 const globals = {
     Buffer: {
         [CONSTRUCT]: {
@@ -685,7 +686,10 @@ const globals = {
             replacedBy: [{ name: "'global'", supported: "0.1.27" }],
         },
     },
-    process: modules.process,
+    process:
+        /** @type {import('../unsupported-features/types.js').DeprecatedInfoTraceMap} */ (
+            modules.process
+        ),
 }
 
 /**

--- a/lib/rules/no-hide-core-modules.js
+++ b/lib/rules/no-hide-core-modules.js
@@ -137,9 +137,6 @@ module.exports = {
 
                         context.report({
                             node: target.node,
-                            loc: /** @type {NonNullable<import('estree').Node["loc"]>} */ (
-                                target.node.loc
-                            ),
                             messageId: "unexpectedImport",
                             data: {
                                 name: path

--- a/lib/rules/no-mixed-requires.js
+++ b/lib/rules/no-mixed-requires.js
@@ -176,10 +176,7 @@ module.exports = {
                 return REQ_MODULE
             }
 
-            if (
-                initExpression.type === "CallExpression" &&
-                initExpression.arguments.length === 0
-            ) {
+            if (initExpression.arguments.length === 0) {
                 // "var x = require();"
                 return REQ_COMPUTED
             }

--- a/lib/rules/no-mixed-requires.js
+++ b/lib/rules/no-mixed-requires.js
@@ -237,14 +237,11 @@ module.exports = {
             const found = {}
 
             for (const declaration of declarations) {
-                if (getDeclarationType(declaration.init) === DECL_REQUIRE) {
-                    found[
-                        inferModuleType(
-                            /** @type {import('estree').Expression} */ (
-                                declaration.init
-                            )
-                        )
-                    ] = true
+                if (
+                    declaration.init != null &&
+                    getDeclarationType(declaration.init) === DECL_REQUIRE
+                ) {
+                    found[inferModuleType(declaration.init)] = true
                 }
             }
 

--- a/lib/rules/no-mixed-requires.js
+++ b/lib/rules/no-mixed-requires.js
@@ -172,19 +172,21 @@ module.exports = {
                 return inferModuleType(initExpression.object)
             }
 
+            if (initExpression.type !== "CallExpression") {
+                return REQ_MODULE
+            }
+
             if (
-                /** @type {import('estree').CallExpression} */ (initExpression)
-                    .arguments.length === 0
+                initExpression.type === "CallExpression" &&
+                initExpression.arguments.length === 0
             ) {
                 // "var x = require();"
                 return REQ_COMPUTED
             }
 
-            const arg = /** @type {import('estree').CallExpression} */ (
-                initExpression
-            ).arguments[0]
+            const arg = initExpression.arguments[0]
 
-            if (arg.type !== "Literal" || typeof arg.value !== "string") {
+            if (arg?.type !== "Literal" || typeof arg.value !== "string") {
                 // "var x = require(42);"
                 return REQ_COMPUTED
             }

--- a/lib/rules/no-path-concat.js
+++ b/lib/rules/no-path-concat.js
@@ -112,7 +112,6 @@ function collectFirstChars(node, sepNodes, globalScope, outNextChars) {
                 }
             }
             break
-        // fallthrough
         default: {
             if (node) {
                 const str = getStringIfConstant(node, globalScope)?.at(0)

--- a/lib/rules/no-path-concat.js
+++ b/lib/rules/no-path-concat.js
@@ -27,18 +27,21 @@ function collectFirstCharsOfTemplateElement(
     globalScope,
     outNextChars
 ) {
-    const element = node.quasis[i].value.cooked
+    const element = node.quasis[i]?.value.cooked
 
     if (element == null) {
         return
     }
-    if (element !== "") {
-        outNextChars.push(element[0])
+
+    const first = element[0]
+    if (first) {
+        outNextChars.push(first)
         return
     }
+
     if (node.expressions.length > i) {
         collectFirstChars(
-            node.expressions[i],
+            node.expressions.at(i),
             sepNodes,
             globalScope,
             outNextChars
@@ -48,14 +51,14 @@ function collectFirstCharsOfTemplateElement(
 
 /**
  * Get the first char of a given node.
- * @param {import('estree').Node} node The `TemplateLiteral` node to get.
+ * @param {import('estree').Node | undefined} node The `TemplateLiteral` node to get.
  * @param {Set<import('estree').Node>} sepNodes The nodes of `path.sep`.
  * @param {import("eslint").Scope.Scope} globalScope The global scope object.
  * @param {string[]} outNextChars The array to collect chars.
  * @returns {void}
  */
 function collectFirstChars(node, sepNodes, globalScope, outNextChars) {
-    switch (node.type) {
+    switch (node?.type) {
         case "AssignmentExpression":
             collectFirstChars(node.right, sepNodes, globalScope, outNextChars)
             break
@@ -102,13 +105,20 @@ function collectFirstChars(node, sepNodes, globalScope, outNextChars) {
         case "MemberExpression":
             if (sepNodes.has(node)) {
                 outNextChars.push(path.sep)
-                break
+            } else {
+                const str = getStringIfConstant(node, globalScope)?.at(0)
+                if (str) {
+                    outNextChars.push(str)
+                }
             }
+            break
         // fallthrough
         default: {
-            const str = getStringIfConstant(node, globalScope)
-            if (str) {
-                outNextChars.push(str[0])
+            if (node) {
+                const str = getStringIfConstant(node, globalScope)?.at(0)
+                if (str) {
+                    outNextChars.push(str)
+                }
             }
         }
     }

--- a/lib/rules/no-path-concat.js
+++ b/lib/rules/no-path-concat.js
@@ -10,6 +10,7 @@ const {
     ReferenceTracker,
     getStringIfConstant,
 } = require("@eslint-community/eslint-utils")
+const { hasParentNode } = require("../util/has-parent-node.js")
 
 /**
  * Get the first char of the specified template element.
@@ -131,37 +132,39 @@ function collectFirstChars(node, sepNodes, globalScope, outNextChars) {
 function isPathSeparator(c) {
     return c === "/" || c === path.sep
 }
-/** @typedef {import('estree').Identifier & { parent: import('estree').Node }} Identifier */
 
 /**
  * Check if the given Identifier node is followed by string concatenation with a
  * path separator.
- * @param {Identifier} node The `__dirname` or `__filename` node to check.
+ * @param {import('estree').Identifier} node The `__dirname` or `__filename` node to check.
  * @param {Set<import('estree').Node>} sepNodes The nodes of `path.sep`.
  * @param {import("eslint").Scope.Scope} globalScope The global scope object.
  * @returns {boolean} `true` if the given Identifier node is followed by string
  * concatenation with a path separator.
  */
 function isConcat(node, sepNodes, globalScope) {
-    const parent = node.parent
+    if (!hasParentNode(node)) {
+        return false
+    }
+
     /** @type {string[]} */
     const nextChars = []
 
     if (
-        parent.type === "BinaryExpression" &&
-        parent.operator === "+" &&
-        parent.left === node
+        node.parent.type === "BinaryExpression" &&
+        node.parent.operator === "+" &&
+        node.parent.left === node
     ) {
         collectFirstChars(
-            parent.right,
+            node.parent.right,
             sepNodes,
             globalScope,
             /* out */ nextChars
         )
-    } else if (parent.type === "TemplateLiteral") {
+    } else if (node.parent.type === "TemplateLiteral") {
         collectFirstCharsOfTemplateElement(
-            parent,
-            parent.expressions.indexOf(node) + 1,
+            node.parent,
+            node.parent.expressions.indexOf(node) + 1,
             sepNodes,
             globalScope,
             /* out */ nextChars
@@ -217,16 +220,12 @@ module.exports = {
                     __filename: { [READ]: true },
                 })) {
                     if (
-                        isConcat(
-                            /** @type {Identifier} */ (node),
-                            sepNodes,
-                            globalScope
-                        )
+                        node.type === "Identifier" &&
+                        hasParentNode(node) &&
+                        isConcat(node, sepNodes, globalScope)
                     ) {
                         context.report({
-                            node: /** @type {import('estree').Node & { parent: import('estree').Node }}*/ (
-                                node
-                            ).parent,
+                            node: node.parent,
                             messageId: "usePathFunctions",
                         })
                     }

--- a/lib/rules/no-unsupported-features/es-syntax.js
+++ b/lib/rules/no-unsupported-features/es-syntax.js
@@ -54,14 +54,16 @@ const ruleMap = Object.entries(features).map(([ruleId, meta]) => {
         ignoreKeys.add(ignoreName)
     }
 
+    const supported = getSemverRange(meta.supported ?? "<0")
+    if (supported == null) {
+        throw new Error(`Invalid semver Range: "${meta.supported}"`)
+    }
     /** @type {RuleMap} */
     const rule = {
         ruleId: ruleId,
         feature: ruleIdNegated,
         ignoreNames: ignoreNames,
-        supported: /** @type {import("semver").Range} */ (
-            getSemverRange(meta.supported ?? "<0")
-        ),
+        supported: supported,
         deprecated: Boolean(meta.deprecated),
     }
 

--- a/lib/rules/no-unsupported-features/es-syntax.js
+++ b/lib/rules/no-unsupported-features/es-syntax.js
@@ -54,18 +54,25 @@ const ruleMap = Object.entries(features).map(([ruleId, meta]) => {
         ignoreKeys.add(ignoreName)
     }
 
-    return {
+    /** @type {RuleMap} */
+    const rule = {
         ruleId: ruleId,
         feature: ruleIdNegated,
         ignoreNames: ignoreNames,
         supported: /** @type {import("semver").Range} */ (
             getSemverRange(meta.supported ?? "<0")
         ),
-        strictMode: meta.strictMode
-            ? getSemverRange(meta.strictMode)
-            : undefined,
         deprecated: Boolean(meta.deprecated),
     }
+
+    if (meta.strictMode) {
+        const range = getSemverRange(meta.strictMode)
+        if (range) {
+            rule.strictMode = range
+        }
+    }
+
+    return rule
 })
 
 /**

--- a/lib/rules/prefer-node-protocol.js
+++ b/lib/rules/prefer-node-protocol.js
@@ -86,7 +86,7 @@ module.exports = {
         }
 
         /**
-         * @param {import('estree').Node} node
+         * @param {import('estree').Node} [node]
          * @returns {node is import('estree').Literal}
          */
         function isStringLiteral(node) {

--- a/lib/rules/prefer-node-protocol.js
+++ b/lib/rules/prefer-node-protocol.js
@@ -4,8 +4,9 @@
  */
 "use strict"
 
+const { Range } = require("semver")
+
 const getConfiguredNodeVersion = require("../util/get-configured-node-version")
-const getSemverRange = require("../util/get-semver-range")
 const visitImport = require("../util/visit-import")
 const visitRequire = require("../util/visit-require")
 const mergeVisitorsInPlace = require("../util/merge-visitors-in-place")
@@ -23,12 +24,8 @@ function isBuiltin(name) {
 
 const messageId = "preferNodeProtocol"
 
-const supportedRangeForEsm = /** @type {import('semver').Range} */ (
-    getSemverRange("^12.20.0 || >= 14.13.1")
-)
-const supportedRangeForCjs = /** @type {import('semver').Range} */ (
-    getSemverRange("^14.18.0 || >= 16.0.0")
-)
+const supportedRangeForEsm = new Range("^12.20.0 || >= 14.13.1")
+const supportedRangeForCjs = new Range("^14.18.0 || >= 16.0.0")
 
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
@@ -156,12 +153,12 @@ module.exports = {
                             continue
                         }
 
-                        const { value } = /** @type {{ value: string }}*/ (node)
                         if (
-                            typeof value !== "string" ||
-                            value.startsWith("node:") ||
-                            !isBuiltin(value) ||
-                            !isBuiltin(`node:${value}`)
+                            !("value" in node) ||
+                            typeof node.value !== "string" ||
+                            node.value.startsWith("node:") ||
+                            !isBuiltin(node.value) ||
+                            !isBuiltin(`node:${node.value}`)
                         ) {
                             continue
                         }
@@ -170,7 +167,7 @@ module.exports = {
                             node,
                             messageId,
                             data: {
-                                moduleName: value,
+                                moduleName: node.value,
                             },
                             fix(fixer) {
                                 const firstCharacterIndex =

--- a/lib/rules/prefer-promises/dns.js
+++ b/lib/rules/prefer-promises/dns.js
@@ -11,29 +11,32 @@ const {
 } = require("@eslint-community/eslint-utils")
 
 /** @type {import('@eslint-community/eslint-utils').TraceMap<boolean>} */
-const traceMap = {
-    dns: {
-        lookup: { [CALL]: true },
-        lookupService: { [CALL]: true },
-        Resolver: { [CONSTRUCT]: true },
-        getServers: { [CALL]: true },
-        resolve: { [CALL]: true },
-        resolve4: { [CALL]: true },
-        resolve6: { [CALL]: true },
-        resolveAny: { [CALL]: true },
-        resolveCname: { [CALL]: true },
-        resolveMx: { [CALL]: true },
-        resolveNaptr: { [CALL]: true },
-        resolveNs: { [CALL]: true },
-        resolvePtr: { [CALL]: true },
-        resolveSoa: { [CALL]: true },
-        resolveSrv: { [CALL]: true },
-        resolveTxt: { [CALL]: true },
-        reverse: { [CALL]: true },
-        setServers: { [CALL]: true },
-    },
+const dns = {
+    lookup: { [CALL]: true },
+    lookupService: { [CALL]: true },
+    Resolver: { [CONSTRUCT]: true },
+    getServers: { [CALL]: true },
+    resolve: { [CALL]: true },
+    resolve4: { [CALL]: true },
+    resolve6: { [CALL]: true },
+    resolveAny: { [CALL]: true },
+    resolveCname: { [CALL]: true },
+    resolveMx: { [CALL]: true },
+    resolveNaptr: { [CALL]: true },
+    resolveNs: { [CALL]: true },
+    resolvePtr: { [CALL]: true },
+    resolveSoa: { [CALL]: true },
+    resolveSrv: { [CALL]: true },
+    resolveTxt: { [CALL]: true },
+    reverse: { [CALL]: true },
+    setServers: { [CALL]: true },
 }
-traceMap["node:dns"] = traceMap.dns
+
+/** @type {import('@eslint-community/eslint-utils').TraceMap<boolean>} */
+const traceMap = {
+    dns: dns,
+    "node:dns": dns,
+}
 
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
@@ -65,7 +68,14 @@ module.exports = {
 
                 for (const { node, path } of references) {
                     const name = path[path.length - 1]
-                    const isClass = name[0] === name[0].toUpperCase()
+                    if (name == null) {
+                        continue
+                    }
+                    const firstLetter = name[0]
+                    if (firstLetter == null) {
+                        continue
+                    }
+                    const isClass = firstLetter === firstLetter.toUpperCase()
                     context.report({
                         node,
                         messageId: isClass

--- a/lib/rules/prefer-promises/fs.js
+++ b/lib/rules/prefer-promises/fs.js
@@ -65,7 +65,11 @@ module.exports = {
                 ]
 
                 for (const { node, path } of references) {
-                    const name = path[path.length - 1]
+                    const name = path.at(-1)
+                    if (name == null) {
+                        continue
+                    }
+
                     context.report({
                         node,
                         messageId: "preferPromises",

--- a/lib/unsupported-features/node-builtins-modules/assert.js
+++ b/lib/unsupported-features/node-builtins-modules/assert.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const assert = {
     assert: { [READ]: { supported: ["0.5.9"] } },
     deepEqual: { [READ]: { supported: ["0.1.21"] } },
@@ -38,6 +40,7 @@ const assert = {
             deprecated: ["20.1.0"],
         },
     },
+    strict: {},
 }
 
 assert.strict = {
@@ -45,7 +48,9 @@ assert.strict = {
     [READ]: { supported: ["9.9.0", "8.13.0"] },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     assert: {
         ...assert,

--- a/lib/unsupported-features/node-builtins-modules/async_hooks.js
+++ b/lib/unsupported-features/node-builtins-modules/async_hooks.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const async_hooks = {
     createHook: { [READ]: { experimental: ["8.1.0"] } },
     executionAsyncResource: { [READ]: { experimental: ["13.9.0", "12.17.0"] } },
@@ -25,7 +27,9 @@ const async_hooks = {
     },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     async_hooks: {
         [READ]: {

--- a/lib/unsupported-features/node-builtins-modules/buffer.js
+++ b/lib/unsupported-features/node-builtins-modules/buffer.js
@@ -2,7 +2,9 @@
 
 const { CONSTRUCT, READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const buffer = {
     constants: { [READ]: { supported: ["8.2.0"] } },
     INSPECT_MAX_BYTES: { [READ]: { supported: ["0.5.4"] } },
@@ -43,7 +45,9 @@ const buffer = {
     },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     buffer: {
         [READ]: { supported: ["0.1.90"] },

--- a/lib/unsupported-features/node-builtins-modules/child_process.js
+++ b/lib/unsupported-features/node-builtins-modules/child_process.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const child_process = {
     exec: { [READ]: { supported: ["0.1.90"] } },
     execFile: { [READ]: { supported: ["0.1.91"] } },
@@ -14,7 +16,9 @@ const child_process = {
     ChildProcess: { [READ]: { supported: ["2.2.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     child_process: {
         [READ]: { supported: ["0.1.90"] },

--- a/lib/unsupported-features/node-builtins-modules/cluster.js
+++ b/lib/unsupported-features/node-builtins-modules/cluster.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const cluster = {
     isMaster: { [READ]: { supported: ["0.8.1"], deprecated: ["16.0.0"] } },
     isPrimary: { [READ]: { supported: ["16.0.0"] } },
@@ -18,7 +20,9 @@ const cluster = {
     Worker: { [READ]: { supported: ["0.7.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     cluster: {
         [READ]: { supported: ["0.7.0"] },

--- a/lib/unsupported-features/node-builtins-modules/console.js
+++ b/lib/unsupported-features/node-builtins-modules/console.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const console = {
     profile: { [READ]: { supported: ["8.0.0"] } },
     profileEnd: { [READ]: { supported: ["8.0.0"] } },
@@ -34,7 +36,9 @@ const console = {
     // timelineEnd: { [READ]: { supported: ["8.0.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     console: {
         [READ]: { supported: ["0.1.100"] },

--- a/lib/unsupported-features/node-builtins-modules/crypto.js
+++ b/lib/unsupported-features/node-builtins-modules/crypto.js
@@ -2,7 +2,9 @@
 
 const { CALL, CONSTRUCT, READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const WebCrypto = {
     [READ]: { experimental: ["15.0.0"], supported: ["19.0.0"] },
     subtle: {
@@ -24,7 +26,9 @@ const WebCrypto = {
     randomUUID: { [READ]: { supported: ["16.7.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const crypto = {
     constants: { [READ]: { supported: ["6.3.0"] } },
     fips: { [READ]: { supported: ["6.0.0"], deprecated: ["10.0.0"] } },
@@ -125,7 +129,9 @@ const crypto = {
     X509Certificate: { [READ]: { supported: ["15.6.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     crypto: {
         [READ]: { supported: ["0.1.92"] },

--- a/lib/unsupported-features/node-builtins-modules/dgram.js
+++ b/lib/unsupported-features/node-builtins-modules/dgram.js
@@ -2,13 +2,17 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const dgram = {
     createSocket: { [READ]: { supported: ["0.1.99"] } },
     Socket: { [READ]: { supported: ["0.1.99"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     dgram: {
         [READ]: { supported: ["0.1.99"] },

--- a/lib/unsupported-features/node-builtins-modules/diagnostics_channel.js
+++ b/lib/unsupported-features/node-builtins-modules/diagnostics_channel.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const diagnostics_channel = {
     hasSubscribers: { [READ]: { supported: ["15.1.0", "14.17.0"] } },
     channel: { [READ]: { supported: ["15.1.0", "14.17.0"] } },
@@ -13,7 +15,9 @@ const diagnostics_channel = {
     TracingChannel: { [READ]: { experimental: ["19.9.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     diagnostics_channel: {
         [READ]: {

--- a/lib/unsupported-features/node-builtins-modules/dns.js
+++ b/lib/unsupported-features/node-builtins-modules/dns.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const dns = {
     Resolver: { [READ]: { supported: ["8.3.0"] } },
     getServers: { [READ]: { supported: ["0.11.3"] } },
@@ -56,7 +58,9 @@ const dns = {
     },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     dns: { ...dns, [READ]: { supported: ["0.1.16"] } },
     "node:dns": { ...dns, [READ]: { supported: ["14.13.1", "12.20.0"] } },

--- a/lib/unsupported-features/node-builtins-modules/domain.js
+++ b/lib/unsupported-features/node-builtins-modules/domain.js
@@ -2,13 +2,17 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const domain = {
     create: { [READ]: { supported: ["0.7.8"] } },
     Domain: { [READ]: { supported: ["0.7.8"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     domain: {
         [READ]: {

--- a/lib/unsupported-features/node-builtins-modules/events.js
+++ b/lib/unsupported-features/node-builtins-modules/events.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const EventEmitterStatic = {
     defaultMaxListeners: { [READ]: { supported: ["0.11.2"] } },
     errorMonitor: { [READ]: { supported: ["13.6.0", "12.17.0"] } },
@@ -27,7 +29,9 @@ const EventEmitterStatic = {
     addAbortListener: { [READ]: { experimental: ["20.5.0", "18.18.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const events = {
     Event: { [READ]: { experimental: ["14.5.0"], supported: ["15.4.0"] } },
     EventTarget: {
@@ -59,7 +63,9 @@ const events = {
     ...EventEmitterStatic,
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     events: {
         [READ]: { supported: ["0.1.26"] },

--- a/lib/unsupported-features/node-builtins-modules/fs.js
+++ b/lib/unsupported-features/node-builtins-modules/fs.js
@@ -2,7 +2,9 @@
 
 const { READ, CALL, CONSTRUCT } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const promises_api = {
     FileHandle: { [READ]: { supported: ["10.0.0"] } },
     access: { [READ]: { supported: ["10.0.0"] } },
@@ -39,7 +41,9 @@ const promises_api = {
     writeFile: { [READ]: { supported: ["10.0.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const callback_api = {
     access: { [READ]: { supported: ["0.11.15"] } },
     appendFile: { [READ]: { supported: ["0.6.7"] } },
@@ -96,7 +100,9 @@ const callback_api = {
     writev: { [READ]: { supported: ["12.9.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const synchronous_api = {
     accessSync: { [READ]: { supported: ["0.11.15"] } },
     appendFileSync: { [READ]: { supported: ["0.6.7"] } },
@@ -147,7 +153,9 @@ const synchronous_api = {
     writevSync: { [READ]: { supported: ["12.9.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const fs = {
     promises: {
         [READ]: {
@@ -174,7 +182,9 @@ const fs = {
     common_objects: { [READ]: { supported: ["0.1.8"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     fs: {
         [READ]: { supported: ["0.1.8"] },

--- a/lib/unsupported-features/node-builtins-modules/http.js
+++ b/lib/unsupported-features/node-builtins-modules/http.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const http = {
     METHODS: { [READ]: { supported: ["0.11.8"] } },
     STATUS_CODES: { [READ]: { supported: ["0.1.22"] } },
@@ -23,7 +25,9 @@ const http = {
     WebSocket: { [READ]: { supported: ["22.5.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     http: {
         [READ]: { supported: ["0.0.1"] },

--- a/lib/unsupported-features/node-builtins-modules/http2.js
+++ b/lib/unsupported-features/node-builtins-modules/http2.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const http2 = {
     constants: { [READ]: { supported: ["8.4.0"] } },
     sensitiveHeaders: { [READ]: { supported: ["15.0.0", "14.18.0"] } },
@@ -25,7 +27,9 @@ const http2 = {
     Http2ServerResponse: { [READ]: { supported: ["8.4.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     http2: {
         [READ]: {

--- a/lib/unsupported-features/node-builtins-modules/https.js
+++ b/lib/unsupported-features/node-builtins-modules/https.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const http = {
     globalAgent: { [READ]: { supported: ["0.5.9"] } },
     createServer: { [READ]: { supported: ["0.3.4"] } },
@@ -12,7 +14,9 @@ const http = {
     Server: { [READ]: { supported: ["0.3.4"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     http: {
         [READ]: { supported: ["0.3.4"] },

--- a/lib/unsupported-features/node-builtins-modules/inspector.js
+++ b/lib/unsupported-features/node-builtins-modules/inspector.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const common_objects = {
     Network: {
         requestWillBeSent: { [READ]: { experimental: ["22.6.0"] } },
@@ -17,19 +19,25 @@ const common_objects = {
     waitForDebugger: { [READ]: { supported: ["12.7.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const promises_api = {
     Session: { [READ]: { supported: ["19.0.0"] } },
     ...common_objects,
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const callback_api = {
     Session: { [READ]: { supported: ["8.0.0"] } },
     ...common_objects,
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     inspector: {
         [READ]: {

--- a/lib/unsupported-features/node-builtins-modules/module.js
+++ b/lib/unsupported-features/node-builtins-modules/module.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const Module = {
     builtinModules: { [READ]: { supported: ["9.3.0", "8.10.0", "6.13.0"] } },
     constants: {
@@ -25,11 +27,14 @@ const Module = {
     syncBuiltinESMExports: { [READ]: { supported: ["12.12.0"] } },
     findSourceMap: { [READ]: { supported: ["13.7.0", "12.17.0"] } },
     SourceMap: { [READ]: { supported: ["13.7.0", "12.17.0"] } },
+    Module: {},
 }
 
 Module.Module = Module
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     module: {
         [READ]: { supported: ["0.3.7"] },

--- a/lib/unsupported-features/node-builtins-modules/net.js
+++ b/lib/unsupported-features/node-builtins-modules/net.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const net = {
     connect: { [READ]: { supported: ["0.0.1"] } },
     createConnection: { [READ]: { supported: ["0.0.1"] } },
@@ -24,7 +26,9 @@ const net = {
     Socket: { [READ]: { supported: ["0.3.4"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     net: {
         [READ]: { supported: ["0.0.1"] },

--- a/lib/unsupported-features/node-builtins-modules/os.js
+++ b/lib/unsupported-features/node-builtins-modules/os.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const os = {
     EOL: { [READ]: { supported: ["0.7.8"] } },
     constants: {
@@ -32,7 +34,9 @@ const os = {
     version: { [READ]: { supported: ["13.11.0", "12.17.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     os: {
         [READ]: { supported: ["0.3.3"] },

--- a/lib/unsupported-features/node-builtins-modules/path.js
+++ b/lib/unsupported-features/node-builtins-modules/path.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const path = {
     delimiter: { [READ]: { supported: ["0.9.3"] } },
     sep: { [READ]: { supported: ["0.7.9"] } },
@@ -20,7 +22,9 @@ const path = {
     toNamespacedPath: { [READ]: { supported: ["9.0.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     path: {
         [READ]: { supported: ["0.1.16"] },

--- a/lib/unsupported-features/node-builtins-modules/perf_hooks.js
+++ b/lib/unsupported-features/node-builtins-modules/perf_hooks.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const perf_hooks = {
     performance: {
         [READ]: { supported: ["8.5.0"] },
@@ -49,7 +51,9 @@ const perf_hooks = {
     RecordableHistogram: { [READ]: { supported: ["15.9.0", "14.18.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     perf_hooks: {
         [READ]: { supported: ["8.5.0"] },

--- a/lib/unsupported-features/node-builtins-modules/process.js
+++ b/lib/unsupported-features/node-builtins-modules/process.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const process = {
     allowedNodeEnvironmentFlags: { [READ]: { supported: ["10.10.0"] } },
     availableMemory: { [READ]: { experimental: ["22.0.0", "20.13.0"] } },
@@ -138,7 +140,9 @@ const process = {
     uptime: { [READ]: { supported: ["0.5.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     process: {
         [READ]: { supported: ["0.1.3"] },

--- a/lib/unsupported-features/node-builtins-modules/punycode.js
+++ b/lib/unsupported-features/node-builtins-modules/punycode.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const punycode = {
     ucs2: { [READ]: { supported: ["0.7.0"] } },
     version: { [READ]: { supported: ["0.6.1"] } },
@@ -12,7 +14,9 @@ const punycode = {
     toUnicode: { [READ]: { supported: ["0.6.1"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     punycode: {
         [READ]: {

--- a/lib/unsupported-features/node-builtins-modules/querystring.js
+++ b/lib/unsupported-features/node-builtins-modules/querystring.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const querystring = {
     decode: { [READ]: { supported: ["0.1.99"] } },
     encode: { [READ]: { supported: ["0.1.99"] } },
@@ -12,7 +14,9 @@ const querystring = {
     unescape: { [READ]: { supported: ["0.1.25"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     querystring: {
         [READ]: { supported: ["0.1.25"] },

--- a/lib/unsupported-features/node-builtins-modules/readline.js
+++ b/lib/unsupported-features/node-builtins-modules/readline.js
@@ -2,14 +2,18 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const promises_api = {
     createInterface: { [READ]: { supported: ["17.0.0"] } },
     Interface: { [READ]: { supported: ["17.0.0"] } },
     Readline: { [READ]: { supported: ["17.0.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const readline = {
     promises: {
         [READ]: { experimental: ["17.0.0"] },
@@ -25,7 +29,9 @@ const readline = {
     InterfaceConstructor: { [READ]: { supported: ["0.1.104"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     readline: {
         [READ]: { supported: ["0.1.98"] },

--- a/lib/unsupported-features/node-builtins-modules/repl.js
+++ b/lib/unsupported-features/node-builtins-modules/repl.js
@@ -2,7 +2,9 @@
 
 const { CALL, READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const repl = {
     start: {
         [READ]: { supported: ["0.1.91"] },
@@ -36,7 +38,9 @@ const repl = {
     },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     repl: {
         [READ]: { supported: ["0.1.91"] },

--- a/lib/unsupported-features/node-builtins-modules/sea.js
+++ b/lib/unsupported-features/node-builtins-modules/sea.js
@@ -2,20 +2,25 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
-const test = {
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
+const sea = {
     isSea: { [READ]: { supported: ["21.7.0", "20.12.0"] } },
     getAsset: { [READ]: { supported: ["21.7.0", "20.12.0"] } },
     getAssetAsBlob: { [READ]: { supported: ["21.7.0", "20.12.0"] } },
     getRawAsset: { [READ]: { supported: ["21.7.0", "20.12.0"] } },
+    sea: {},
 }
 
-test.test = test
+sea.sea = sea
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     "node:sea": {
         [READ]: { experimental: ["21.7.0", "20.12.0"] },
-        ...test,
+        ...sea,
     },
 }

--- a/lib/unsupported-features/node-builtins-modules/sqlite.js
+++ b/lib/unsupported-features/node-builtins-modules/sqlite.js
@@ -2,13 +2,17 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const sqlite = {
     DatabaseSync: { [READ]: { supported: ["22.5.0"] } },
     StatementSync: { [READ]: { supported: ["22.5.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     "node:sqlite": {
         [READ]: { experimental: ["22.5.0"] },

--- a/lib/unsupported-features/node-builtins-modules/stream.js
+++ b/lib/unsupported-features/node-builtins-modules/stream.js
@@ -2,8 +2,6 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-// TODO: https://nodejs.org/docs/latest/api/webstreams.html
-
 /**
  * @satisfies {import('../types.js').SupportVersionTraceMap}
  */

--- a/lib/unsupported-features/node-builtins-modules/stream.js
+++ b/lib/unsupported-features/node-builtins-modules/stream.js
@@ -4,7 +4,9 @@ const { READ } = require("@eslint-community/eslint-utils")
 
 // TODO: https://nodejs.org/docs/latest/api/webstreams.html
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const Readable = {
     [READ]: { supported: ["0.9.4"] },
     from: { [READ]: { supported: ["12.3.0", "10.17.0"] } },
@@ -13,14 +15,18 @@ const Readable = {
     toWeb: { [READ]: { experimental: ["17.0.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const Writable = {
     [READ]: { supported: ["0.9.4"] },
     fromWeb: { [READ]: { experimental: ["17.0.0"] } },
     toWeb: { [READ]: { experimental: ["17.0.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const Duplex = {
     [READ]: { supported: ["0.9.4"] },
     from: { [READ]: { supported: ["16.8.0"] } },
@@ -30,13 +36,17 @@ const Duplex = {
 
 const Transform = Duplex
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const StreamPromise = {
     pipeline: { [READ]: { supported: ["15.0.0"] } },
     finished: { [READ]: { supported: ["15.0.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const Stream = {
     promises: {
         [READ]: { supported: ["15.0.0"] },
@@ -59,7 +69,9 @@ const Stream = {
     setDefaultHighWaterMark: { [READ]: { supported: ["19.9.0", "18.17.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const WebStream = {
     ReadableStream: {
         [READ]: { supported: ["16.5.0"] },
@@ -92,7 +104,9 @@ const StreamConsumer = {
     text: { [READ]: { supported: ["16.7.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     stream: {
         [READ]: { supported: ["0.9.4"] },

--- a/lib/unsupported-features/node-builtins-modules/string_decoder.js
+++ b/lib/unsupported-features/node-builtins-modules/string_decoder.js
@@ -2,12 +2,16 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const string_decoder = {
     StringDecoder: { [READ]: { supported: ["0.1.99"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     string_decoder: {
         [READ]: { supported: ["0.1.99"] },

--- a/lib/unsupported-features/node-builtins-modules/test.js
+++ b/lib/unsupported-features/node-builtins-modules/test.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const test = {
     run: { [READ]: { supported: ["18.9.0", "16.19.0"] } },
     skip: { [READ]: { supported: ["20.2.0", "18.17.0"] } },
@@ -42,11 +44,14 @@ const test = {
     TestsStream: { [READ]: { supported: ["18.9.0", "16.19.0"] } },
     TestContext: { [READ]: { supported: ["18.0.0", "16.17.0"] } },
     SuiteContext: { [READ]: { supported: ["18.7.0", "16.17.0"] } },
+    test: {},
 }
 
 test.test = test
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     "node:test": {
         [READ]: {

--- a/lib/unsupported-features/node-builtins-modules/timers.js
+++ b/lib/unsupported-features/node-builtins-modules/timers.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const promises_api = {
     setTimeout: { [READ]: { supported: ["15.0.0"] } },
     setImmediate: { [READ]: { supported: ["15.0.0"] } },
@@ -13,7 +15,9 @@ const promises_api = {
     },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const timers = {
     Immediate: { [READ]: { supported: ["0.9.1"] } },
     Timeout: { [READ]: { supported: ["0.9.1"] } },
@@ -31,7 +35,9 @@ const timers = {
     // enroll: [Function: deprecated]
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     timers: {
         [READ]: { supported: ["0.9.1"] },

--- a/lib/unsupported-features/node-builtins-modules/tls.js
+++ b/lib/unsupported-features/node-builtins-modules/tls.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const tls = {
     rootCertificates: { [READ]: { supported: ["12.3.0"] } },
     DEFAULT_ECDH_CURVE: { [READ]: { supported: ["0.11.13"] } },
@@ -24,7 +26,9 @@ const tls = {
     TLSSocket: { [READ]: { supported: ["0.11.4"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     tls: {
         [READ]: { supported: ["0.3.2"] },

--- a/lib/unsupported-features/node-builtins-modules/trace_events.js
+++ b/lib/unsupported-features/node-builtins-modules/trace_events.js
@@ -2,13 +2,17 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const trace_events = {
     createTracing: { [READ]: { supported: ["10.0.0"] } },
     getEnabledCategories: { [READ]: { supported: ["10.0.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     trace_events: {
         [READ]: { experimental: ["10.0.0"] },

--- a/lib/unsupported-features/node-builtins-modules/tty.js
+++ b/lib/unsupported-features/node-builtins-modules/tty.js
@@ -2,14 +2,18 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const tty = {
     isatty: { [READ]: { supported: ["0.5.8"] } },
     ReadStream: { [READ]: { supported: ["0.5.8"] } },
     WriteStream: { [READ]: { supported: ["0.5.8"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     tty: {
         [READ]: { supported: ["0.5.8"] },

--- a/lib/unsupported-features/node-builtins-modules/url.js
+++ b/lib/unsupported-features/node-builtins-modules/url.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const url = {
     domainToASCII: { [READ]: { supported: ["7.4.0", "6.13.0"] } },
     domainToUnicode: { [READ]: { supported: ["7.4.0", "6.13.0"] } },
@@ -20,7 +22,9 @@ const url = {
     Url: { [READ]: { supported: ["0.1.25"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     url: {
         [READ]: { supported: ["0.1.25"] },

--- a/lib/unsupported-features/node-builtins-modules/util.js
+++ b/lib/unsupported-features/node-builtins-modules/util.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const types = {
     [READ]: { supported: ["10.0.0"] },
     isExternal: { [READ]: { supported: ["10.0.0"] } },
@@ -52,7 +54,9 @@ const types = {
     },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const deprecated = {
     _extend: { [READ]: { supported: ["0.7.5"], deprecated: ["6.0.0"] } },
     isArray: { [READ]: { supported: ["0.6.0"], deprecated: ["4.0.0"] } },
@@ -75,7 +79,9 @@ const deprecated = {
     log: { [READ]: { supported: ["0.3.0"], deprecated: ["6.0.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const util = {
     promisify: {
         [READ]: { supported: ["8.0.0"] },
@@ -119,7 +125,9 @@ const util = {
     ...deprecated,
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     util: util,
     "node:util": { ...util, [READ]: { supported: ["14.13.1", "12.20.0"] } },

--- a/lib/unsupported-features/node-builtins-modules/v8.js
+++ b/lib/unsupported-features/node-builtins-modules/v8.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const v8 = {
     serialize: { [READ]: { supported: ["8.0.0"] } },
     deserialize: { [READ]: { supported: ["8.0.0"] } },
@@ -45,7 +47,9 @@ const v8 = {
     GCProfiler: { [READ]: { supported: ["19.6.0", "18.15.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     v8: { ...v8, [READ]: { supported: ["1.0.0"] } },
     "node:v8": { ...v8, [READ]: { supported: ["14.13.1", "12.20.0"] } },

--- a/lib/unsupported-features/node-builtins-modules/vm.js
+++ b/lib/unsupported-features/node-builtins-modules/vm.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const vm = {
     constants: { [READ]: { supported: ["20.12.0", "21.7.0"] } },
     compileFunction: { [READ]: { supported: ["10.10.0"] } },
@@ -19,7 +21,9 @@ const vm = {
     SyntheticModule: { [READ]: { experimental: ["13.0.0", "12.16.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     vm: vm,
     "node:vm": { ...vm, [READ]: { supported: ["14.13.1", "12.20.0"] } },

--- a/lib/unsupported-features/node-builtins-modules/wasi.js
+++ b/lib/unsupported-features/node-builtins-modules/wasi.js
@@ -2,12 +2,16 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const wasi = {
     WASI: { [READ]: { supported: ["13.3.0", "12.16.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     wasi: wasi,
     "node:wasi": { ...wasi, [READ]: { supported: ["14.13.1", "12.20.0"] } },

--- a/lib/unsupported-features/node-builtins-modules/worker_threads.js
+++ b/lib/unsupported-features/node-builtins-modules/worker_threads.js
@@ -2,7 +2,9 @@
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const worker_threads = {
     isMainThread: { [READ]: { supported: ["10.5.0"] } },
     parentPort: { [READ]: { supported: ["10.5.0"] } },
@@ -36,7 +38,9 @@ const worker_threads = {
     Worker: { [READ]: { supported: ["10.5.0"] } },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     worker_threads: {
         ...worker_threads,

--- a/lib/unsupported-features/node-builtins-modules/zlib.js
+++ b/lib/unsupported-features/node-builtins-modules/zlib.js
@@ -2,7 +2,9 @@
 
 const { CALL, READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 const zlib = {
     constants: { [READ]: { supported: ["7.0.0"] } },
     crc32: { [READ]: { supported: ["22.2.0", "20.15.0"] } },
@@ -71,7 +73,9 @@ const zlib = {
     },
 }
 
-/** @type {import('../types.js').SupportVersionTraceMap} */
+/**
+ * @satisfies {import('../types.js').SupportVersionTraceMap}
+ */
 module.exports = {
     zlib: zlib,
     "node:zlib": {

--- a/lib/unsupported-features/node-builtins.js
+++ b/lib/unsupported-features/node-builtins.js
@@ -1,9 +1,10 @@
 "use strict"
 
-/** @type {import('./types.js').SupportVersionTraceMap} */
 const NodeBuiltinGlobals = require("./node-globals.js")
 
-/** @type {import('./types.js').SupportVersionTraceMap} */
+/**
+ * @type {import('./types.js').SupportVersionTraceMap}
+ */
 const NodeBuiltinModules = {
     ...require("./node-builtins-modules/assert.js"),
     ...require("./node-builtins-modules/async_hooks.js"),

--- a/lib/unsupported-features/node-globals.js
+++ b/lib/unsupported-features/node-globals.js
@@ -26,7 +26,9 @@ const { worker_threads } = workerThreadsModule
 
 const { READ } = require("@eslint-community/eslint-utils")
 
-/** @type {import('./types.js').SupportVersionTraceMap} */
+/**
+ * @type {import('./types.js').SupportVersionTraceMap}
+ */
 const nodeGlobals = {
     __filename: { [READ]: { supported: ["0.0.1"] } },
     __dirname: { [READ]: { supported: ["0.1.27"] } },
@@ -120,12 +122,12 @@ const nodeGlobals = {
     Storage: { [READ]: { experimental: ["22.4.0"] } },
 
     // module.buffer
-    Blob: buffer?.Blob,
+    Blob: buffer.Blob,
     Buffer: {
-        ...buffer?.Buffer,
+        ...buffer.Buffer,
         [READ]: { supported: ["0.1.103"] },
     },
-    File: buffer?.File,
+    File: buffer.File,
     atob: { [READ]: { supported: ["16.0.0"] } },
     btoa: { [READ]: { supported: ["16.0.0"] } },
 
@@ -134,7 +136,7 @@ const nodeGlobals = {
 
     // module.crypto
     crypto: {
-        ...crypto?.webcrypto,
+        ...crypto.webcrypto,
         [READ]: { experimental: ["17.6.0", "16.15.0"], supported: ["23.0.0"] },
     },
     Crypto: {
@@ -150,36 +152,36 @@ const nodeGlobals = {
     CustomEvent: {
         [READ]: { experimental: ["18.7.0", "16.17.0"], supported: ["23.0.0"] },
     },
-    Event: events?.Event,
-    EventTarget: events?.EventTarget,
+    Event: events.Event,
+    EventTarget: events.EventTarget,
 
     // module.perf_hooks
     PerformanceEntry: {
-        ...perf_hooks?.PerformanceEntry,
+        ...perf_hooks.PerformanceEntry,
         [READ]: { supported: ["19.0.0"] },
     },
     PerformanceMark: {
-        ...perf_hooks?.PerformanceMark,
+        ...perf_hooks.PerformanceMark,
         [READ]: { supported: ["19.0.0"] },
     },
     PerformanceMeasure: {
-        ...perf_hooks?.PerformanceMeasure,
+        ...perf_hooks.PerformanceMeasure,
         [READ]: { supported: ["19.0.0"] },
     },
     PerformanceObserver: {
-        ...perf_hooks?.PerformanceObserver,
+        ...perf_hooks.PerformanceObserver,
         [READ]: { supported: ["19.0.0"] },
     },
     PerformanceObserverEntryList: {
-        ...perf_hooks?.PerformanceObserverEntryList,
+        ...perf_hooks.PerformanceObserverEntryList,
         [READ]: { supported: ["19.0.0"] },
     },
     PerformanceResourceTiming: {
-        ...perf_hooks?.PerformanceResourceTiming,
+        ...perf_hooks.PerformanceResourceTiming,
         [READ]: { supported: ["19.0.0"] },
     },
     performance: {
-        ...perf_hooks?.performance,
+        ...perf_hooks.performance,
         [READ]: { supported: ["16.0.0"] },
     },
 
@@ -188,116 +190,115 @@ const nodeGlobals = {
 
     // module.stream
     ReadableStream: {
-        ...WebStream?.ReadableStream,
+        ...WebStream.ReadableStream,
         [READ]: { experimental: ["18.0.0"] },
     },
     ReadableStreamDefaultReader: {
-        ...WebStream?.ReadableStreamDefaultReader,
+        ...WebStream.ReadableStreamDefaultReader,
         [READ]: { experimental: ["18.0.0"] },
     },
     ReadableStreamBYOBReader: {
-        ...WebStream?.ReadableStreamBYOBReader,
+        ...WebStream.ReadableStreamBYOBReader,
         [READ]: { experimental: ["18.0.0"] },
     },
     ReadableStreamDefaultController: {
-        ...WebStream?.ReadableStreamDefaultController,
+        ...WebStream.ReadableStreamDefaultController,
         [READ]: { experimental: ["18.0.0"] },
     },
     ReadableByteStreamController: {
-        ...WebStream?.ReadableByteStreamController,
+        ...WebStream.ReadableByteStreamController,
         [READ]: { experimental: ["18.0.0"] },
     },
     ReadableStreamBYOBRequest: {
-        ...WebStream?.ReadableStreamBYOBRequest,
+        ...WebStream.ReadableStreamBYOBRequest,
         [READ]: { experimental: ["18.0.0"] },
     },
     WritableStream: {
-        ...WebStream?.WritableStream,
+        ...WebStream.WritableStream,
         [READ]: { experimental: ["18.0.0"] },
     },
     WritableStreamDefaultWriter: {
-        ...WebStream?.WritableStreamDefaultWriter,
+        ...WebStream.WritableStreamDefaultWriter,
         [READ]: { experimental: ["18.0.0"] },
     },
     WritableStreamDefaultController: {
-        ...WebStream?.WritableStreamDefaultController,
+        ...WebStream.WritableStreamDefaultController,
         [READ]: { experimental: ["18.0.0"] },
     },
     TransformStream: {
-        ...WebStream?.TransformStream,
+        ...WebStream.TransformStream,
         [READ]: { experimental: ["18.0.0"] },
     },
     TransformStreamDefaultController: {
-        ...WebStream?.TransformStreamDefaultController,
+        ...WebStream.TransformStreamDefaultController,
         [READ]: { experimental: ["18.0.0"] },
     },
     ByteLengthQueuingStrategy: {
-        ...WebStream?.ByteLengthQueuingStrategy,
+        ...WebStream.ByteLengthQueuingStrategy,
         [READ]: { experimental: ["18.0.0"] },
     },
     CountQueuingStrategy: {
-        ...WebStream?.CountQueuingStrategy,
+        ...WebStream.CountQueuingStrategy,
         [READ]: { experimental: ["18.0.0"] },
     },
     TextEncoderStream: {
-        ...WebStream?.TextEncoderStream,
+        ...WebStream.TextEncoderStream,
         [READ]: { experimental: ["18.0.0"] },
     },
     TextDecoderStream: {
-        ...WebStream?.TextDecoderStream,
+        ...WebStream.TextDecoderStream,
         [READ]: { experimental: ["18.0.0"] },
     },
     CompressionStream: {
-        ...WebStream?.CompressionStream,
+        ...WebStream.CompressionStream,
         [READ]: { experimental: ["18.0.0"] },
     },
     DecompressionStream: {
-        ...WebStream?.DecompressionStream,
+        ...WebStream.DecompressionStream,
         [READ]: { experimental: ["18.0.0"] },
     },
 
     // module.timers
-    setInterval: timers?.setInterval,
-    clearInterval: timers?.clearInterval,
-    setTimeout: timers?.setTimeout,
-    clearTimeout: timers?.clearTimeout,
-    setImmediate: timers?.setImmediate,
-    clearImmediate: timers?.clearImmediate,
+    setInterval: timers.setInterval,
+    clearInterval: timers.clearInterval,
+    setTimeout: timers.setTimeout,
+    clearTimeout: timers.clearTimeout,
+    setImmediate: timers.setImmediate,
+    clearImmediate: timers.clearImmediate,
 
     // module.url
     URL: {
-        ...url?.URL,
+        ...url.URL,
         [READ]: { supported: ["10.0.0"] },
     },
     URLSearchParams: {
-        ...url?.URLSearchParams,
+        ...url.URLSearchParams,
         [READ]: { supported: ["10.0.0"] },
     },
 
     // module.util
     TextDecoder: {
-        ...util?.TextDecoder,
+        ...util.TextDecoder,
         [READ]: { supported: ["11.0.0"] },
     },
     TextEncoder: {
-        ...util?.TextEncoder,
+        ...util.TextEncoder,
         [READ]: { supported: ["11.0.0"] },
     },
 
     // module.worker_threads
     BroadcastChannel: {
-        ...worker_threads?.BroadcastChannel,
+        ...worker_threads.BroadcastChannel,
         [READ]: { supported: ["18.0.0"] },
     },
     MessageChannel: {
-        ...worker_threads?.MessageChannel,
+        ...worker_threads.MessageChannel,
         [READ]: { supported: ["15.0.0"] },
     },
     MessagePort: {
-        ...worker_threads?.MessagePort,
+        ...worker_threads.MessagePort,
         [READ]: { supported: ["15.0.0"] },
     },
 }
 
-/** @type {import('./types.js').SupportVersionTraceMap} */
 module.exports = nodeGlobals

--- a/lib/unsupported-features/node-globals.js
+++ b/lib/unsupported-features/node-globals.js
@@ -120,12 +120,12 @@ const nodeGlobals = {
     Storage: { [READ]: { experimental: ["22.4.0"] } },
 
     // module.buffer
-    Blob: buffer.Blob,
+    Blob: buffer?.Blob,
     Buffer: {
-        ...buffer.Buffer,
+        ...buffer?.Buffer,
         [READ]: { supported: ["0.1.103"] },
     },
-    File: buffer.File,
+    File: buffer?.File,
     atob: { [READ]: { supported: ["16.0.0"] } },
     btoa: { [READ]: { supported: ["16.0.0"] } },
 
@@ -134,7 +134,7 @@ const nodeGlobals = {
 
     // module.crypto
     crypto: {
-        ...crypto.webcrypto,
+        ...crypto?.webcrypto,
         [READ]: { experimental: ["17.6.0", "16.15.0"], supported: ["23.0.0"] },
     },
     Crypto: {
@@ -150,36 +150,36 @@ const nodeGlobals = {
     CustomEvent: {
         [READ]: { experimental: ["18.7.0", "16.17.0"], supported: ["23.0.0"] },
     },
-    Event: events.Event,
-    EventTarget: events.EventTarget,
+    Event: events?.Event,
+    EventTarget: events?.EventTarget,
 
     // module.perf_hooks
     PerformanceEntry: {
-        ...perf_hooks.PerformanceEntry,
+        ...perf_hooks?.PerformanceEntry,
         [READ]: { supported: ["19.0.0"] },
     },
     PerformanceMark: {
-        ...perf_hooks.PerformanceMark,
+        ...perf_hooks?.PerformanceMark,
         [READ]: { supported: ["19.0.0"] },
     },
     PerformanceMeasure: {
-        ...perf_hooks.PerformanceMeasure,
+        ...perf_hooks?.PerformanceMeasure,
         [READ]: { supported: ["19.0.0"] },
     },
     PerformanceObserver: {
-        ...perf_hooks.PerformanceObserver,
+        ...perf_hooks?.PerformanceObserver,
         [READ]: { supported: ["19.0.0"] },
     },
     PerformanceObserverEntryList: {
-        ...perf_hooks.PerformanceObserverEntryList,
+        ...perf_hooks?.PerformanceObserverEntryList,
         [READ]: { supported: ["19.0.0"] },
     },
     PerformanceResourceTiming: {
-        ...perf_hooks.PerformanceResourceTiming,
+        ...perf_hooks?.PerformanceResourceTiming,
         [READ]: { supported: ["19.0.0"] },
     },
     performance: {
-        ...perf_hooks.performance,
+        ...perf_hooks?.performance,
         [READ]: { supported: ["16.0.0"] },
     },
 
@@ -188,113 +188,113 @@ const nodeGlobals = {
 
     // module.stream
     ReadableStream: {
-        ...WebStream.ReadableStream,
+        ...WebStream?.ReadableStream,
         [READ]: { experimental: ["18.0.0"] },
     },
     ReadableStreamDefaultReader: {
-        ...WebStream.ReadableStreamDefaultReader,
+        ...WebStream?.ReadableStreamDefaultReader,
         [READ]: { experimental: ["18.0.0"] },
     },
     ReadableStreamBYOBReader: {
-        ...WebStream.ReadableStreamBYOBReader,
+        ...WebStream?.ReadableStreamBYOBReader,
         [READ]: { experimental: ["18.0.0"] },
     },
     ReadableStreamDefaultController: {
-        ...WebStream.ReadableStreamDefaultController,
+        ...WebStream?.ReadableStreamDefaultController,
         [READ]: { experimental: ["18.0.0"] },
     },
     ReadableByteStreamController: {
-        ...WebStream.ReadableByteStreamController,
+        ...WebStream?.ReadableByteStreamController,
         [READ]: { experimental: ["18.0.0"] },
     },
     ReadableStreamBYOBRequest: {
-        ...WebStream.ReadableStreamBYOBRequest,
+        ...WebStream?.ReadableStreamBYOBRequest,
         [READ]: { experimental: ["18.0.0"] },
     },
     WritableStream: {
-        ...WebStream.WritableStream,
+        ...WebStream?.WritableStream,
         [READ]: { experimental: ["18.0.0"] },
     },
     WritableStreamDefaultWriter: {
-        ...WebStream.WritableStreamDefaultWriter,
+        ...WebStream?.WritableStreamDefaultWriter,
         [READ]: { experimental: ["18.0.0"] },
     },
     WritableStreamDefaultController: {
-        ...WebStream.WritableStreamDefaultController,
+        ...WebStream?.WritableStreamDefaultController,
         [READ]: { experimental: ["18.0.0"] },
     },
     TransformStream: {
-        ...WebStream.TransformStream,
+        ...WebStream?.TransformStream,
         [READ]: { experimental: ["18.0.0"] },
     },
     TransformStreamDefaultController: {
-        ...WebStream.TransformStreamDefaultController,
+        ...WebStream?.TransformStreamDefaultController,
         [READ]: { experimental: ["18.0.0"] },
     },
     ByteLengthQueuingStrategy: {
-        ...WebStream.ByteLengthQueuingStrategy,
+        ...WebStream?.ByteLengthQueuingStrategy,
         [READ]: { experimental: ["18.0.0"] },
     },
     CountQueuingStrategy: {
-        ...WebStream.CountQueuingStrategy,
+        ...WebStream?.CountQueuingStrategy,
         [READ]: { experimental: ["18.0.0"] },
     },
     TextEncoderStream: {
-        ...WebStream.TextEncoderStream,
+        ...WebStream?.TextEncoderStream,
         [READ]: { experimental: ["18.0.0"] },
     },
     TextDecoderStream: {
-        ...WebStream.TextDecoderStream,
+        ...WebStream?.TextDecoderStream,
         [READ]: { experimental: ["18.0.0"] },
     },
     CompressionStream: {
-        ...WebStream.CompressionStream,
+        ...WebStream?.CompressionStream,
         [READ]: { experimental: ["18.0.0"] },
     },
     DecompressionStream: {
-        ...WebStream.DecompressionStream,
+        ...WebStream?.DecompressionStream,
         [READ]: { experimental: ["18.0.0"] },
     },
 
     // module.timers
-    setInterval: timers.setInterval,
-    clearInterval: timers.clearInterval,
-    setTimeout: timers.setTimeout,
-    clearTimeout: timers.clearTimeout,
-    setImmediate: timers.setImmediate,
-    clearImmediate: timers.clearImmediate,
+    setInterval: timers?.setInterval,
+    clearInterval: timers?.clearInterval,
+    setTimeout: timers?.setTimeout,
+    clearTimeout: timers?.clearTimeout,
+    setImmediate: timers?.setImmediate,
+    clearImmediate: timers?.clearImmediate,
 
     // module.url
     URL: {
-        ...url.URL,
+        ...url?.URL,
         [READ]: { supported: ["10.0.0"] },
     },
     URLSearchParams: {
-        ...url.URLSearchParams,
+        ...url?.URLSearchParams,
         [READ]: { supported: ["10.0.0"] },
     },
 
     // module.util
     TextDecoder: {
-        ...util.TextDecoder,
+        ...util?.TextDecoder,
         [READ]: { supported: ["11.0.0"] },
     },
     TextEncoder: {
-        ...util.TextEncoder,
+        ...util?.TextEncoder,
         [READ]: { supported: ["11.0.0"] },
     },
 
     // module.worker_threads
     BroadcastChannel: {
-        ...worker_threads.BroadcastChannel,
+        ...worker_threads?.BroadcastChannel,
         [READ]: { supported: ["18.0.0"] },
     },
     MessageChannel: {
-        ...worker_threads.MessageChannel,
+        ...worker_threads?.MessageChannel,
         [READ]: { supported: ["15.0.0"] },
     },
     MessagePort: {
-        ...worker_threads.MessagePort,
+        ...worker_threads?.MessagePort,
         [READ]: { supported: ["15.0.0"] },
     },
 }

--- a/lib/util/check-existence.js
+++ b/lib/util/check-existence.js
@@ -18,9 +18,6 @@ function markMissing(context, target) {
 
     context.report({
         node: target.node,
-        loc: /** @type {import('eslint').AST.SourceLocation} */ (
-            target.node.loc
-        ),
         messageId: "notFound",
         data: { resolveError: target.resolveError },
     })

--- a/lib/util/check-extraneous.js
+++ b/lib/util/check-extraneous.js
@@ -34,20 +34,18 @@ exports.checkExtraneous = function checkExtraneous(context, filePath, targets) {
     )
 
     for (const target of targets) {
-        const extraneous =
+        if (
             target.moduleName != null &&
             target.filePath != null &&
             !dependencies.has(target.moduleName) &&
             !allowed.has(target.moduleName)
-
-        if (extraneous) {
+        ) {
             context.report({
                 node: target.node,
-                loc: /** @type {import('eslint').AST.SourceLocation} */ (
-                    target.node.loc
-                ),
                 messageId: "extraneous",
-                data: /** @type {Record<string, *>} */ (target),
+                data: {
+                    moduleName: target.moduleName,
+                },
             })
         }
     }

--- a/lib/util/check-publish.js
+++ b/lib/util/check-publish.js
@@ -81,9 +81,6 @@ exports.checkPublish = function checkPublish(
             if (isPrivateFile() || isDevPackage()) {
                 context.report({
                     node: target.node,
-                    loc: /** @type {import('estree').SourceLocation} */ (
-                        target.node.loc
-                    ),
                     messageId: "notPublished",
                     data: { name: target.moduleName || target.name },
                 })

--- a/lib/util/extend-trackmap-with-node-prefix.js
+++ b/lib/util/extend-trackmap-with-node-prefix.js
@@ -14,7 +14,7 @@ module.exports = function extendTraceMapWithNodePrefix(modules) {
         ...Object.fromEntries(
             Object.entries(modules)
                 .map(([name, value]) => [`node:${name}`, value])
-                .filter(([name]) => isBuiltin(/** @type {string} */ (name)))
+                .filter(([name]) => typeof name === "string" && isBuiltin(name))
         ),
     }
     return ret

--- a/lib/util/get-configured-node-version.js
+++ b/lib/util/get-configured-node-version.js
@@ -4,8 +4,11 @@
  */
 "use strict"
 
+const { Range } = require("semver")
 const { getPackageJson } = require("./get-package-json")
 const getSemverRange = require("./get-semver-range")
+
+const fallbackRange = new Range(">=16.0.0")
 
 /**
  * Gets `version` property from a given option object.
@@ -24,14 +27,18 @@ function getVersionRange(option) {
 /**
  * Get the `engines.node` field of package.json.
  * @param {import('eslint').Rule.RuleContext} context The path to the current linting file.
- * @returns {import("semver").Range|undefined} The range object of the `engines.node` field.
+ * @returns {import("semver").Range | undefined} The range object of the `engines.node` field.
  */
 function getEnginesNode(context) {
     const filename = context.filename ?? context.getFilename()
     const info = getPackageJson(filename)
-    const engines = /** @type {Engines | undefined} */ (info?.engines)
-    if (typeof engines?.node === "string") {
-        return getSemverRange(engines?.node)
+    if (
+        info?.engines != null &&
+        typeof info?.engines === "object" &&
+        "node" in info.engines &&
+        typeof info?.engines?.node === "string"
+    ) {
+        return getSemverRange(info.engines.node)
     }
 }
 
@@ -52,7 +59,7 @@ module.exports = function getConfiguredNodeVersion(context) {
         getVersionRange(context.settings?.n) ??
         getVersionRange(context.settings?.node) ??
         getEnginesNode(context) ??
-        /** @type {import("semver").Range} */ (getSemverRange(">=16.0.0"))
+        fallbackRange
     )
 }
 

--- a/lib/util/has-parent-node.js
+++ b/lib/util/has-parent-node.js
@@ -1,0 +1,18 @@
+"use strict"
+
+/**
+ * @param {import('estree').Node} node
+ * @returns {node is (import('estree').Node & { parent: import('estree').Node })}
+ */
+function hasParentNode(node) {
+    return (
+        typeof node.type === "string" &&
+        "parent" in node &&
+        node.parent != null &&
+        typeof node.parent === "object" &&
+        "type" in node.parent &&
+        typeof node.parent.type === "string"
+    )
+}
+
+module.exports = { hasParentNode }

--- a/lib/util/import-target.js
+++ b/lib/util/import-target.js
@@ -259,11 +259,10 @@ module.exports = class ImportTarget {
     }
 
     /**
-     * @param {string} _baseDir
      * @param {unknown} error
      * @returns {void}
      */
-    handleResolutionError(_baseDir, error) {
+    handleResolutionError(error) {
         if (error instanceof Error === false) {
             throw error
         }
@@ -327,7 +326,7 @@ module.exports = class ImportTarget {
                 const resolved = requireResolve(baseDir, this.name)
                 if (typeof resolved === "string") return resolved
             } catch (error) {
-                this.handleResolutionError(baseDir, error)
+                this.handleResolutionError(error)
             }
         }
 

--- a/lib/util/import-target.js
+++ b/lib/util/import-target.js
@@ -48,7 +48,7 @@ function removeTrailWildcard(input) {
 /**
  * Initialize this instance.
  * @param {import('eslint').Rule.RuleContext} context - The context for the import origin.
- * @returns {import('enhanced-resolve').ResolveOptions['alias'] & {}}
+ * @returns {NonNullable<import('enhanced-resolve').ResolveOptions['alias']>}
  */
 function getTSConfigAliases(context) {
     const tsConfig = getTSConfigForContext(context)

--- a/lib/util/import-target.js
+++ b/lib/util/import-target.js
@@ -16,7 +16,11 @@ const { getTSConfigForContext } = require("./get-tsconfig.js")
 const getTypescriptExtensionMap = require("./get-typescript-extension-map")
 
 const nodeBuiltinFallback = Object.keys(NodeBuiltinModules).map(
-    name => /** @type {const} */ ({ name, alias: false })
+    /**
+     * @param {string} name
+     * @returns {{ name: string; alias: false }}
+     */
+    name => ({ name: name, alias: false })
 )
 
 /**

--- a/lib/util/import-target.js
+++ b/lib/util/import-target.js
@@ -44,7 +44,7 @@ function removeTrailWildcard(input) {
 /**
  * Initialize this instance.
  * @param {import('eslint').Rule.RuleContext} context - The context for the import origin.
- * @returns {import('enhanced-resolve').ResolveOptions['alias'] | undefined}
+ * @returns {import('enhanced-resolve').ResolveOptions['alias'] & {}}
  */
 function getTSConfigAliases(context) {
     const tsConfig = getTSConfigForContext(context)
@@ -52,7 +52,7 @@ function getTSConfigAliases(context) {
     const paths = tsConfig?.config?.compilerOptions?.paths
 
     if (tsConfig?.path == null || paths == null) {
-        return
+        return {}
     }
 
     return Object.entries(paths).map(([name, alias]) => ({
@@ -273,7 +273,7 @@ module.exports = class ImportTarget {
      */
     getFilePath() {
         const conditionNames = ["node", "require"]
-        const { extensions } = this.options
+
         const mainFields = []
         const mainFiles = []
 
@@ -294,25 +294,23 @@ module.exports = class ImportTarget {
             mainFiles.push("index")
         }
 
-        let alias = undefined
-        let extensionAlias = undefined
-
-        if (isTypescript(this.context)) {
-            alias = getTSConfigAliases(this.context)
-            extensionAlias = getTypescriptExtensionMap(this.context).backward
-        }
-
         /** @type {import('enhanced-resolve').ResolveOptionsOptionalFS} */
         this.resolverConfig = {
-            conditionNames: conditionNames,
-            extensions: extensions ?? [],
-            mainFields: mainFields ?? [],
-            mainFiles: mainFiles ?? [],
-
-            extensionAlias: extensionAlias ?? {},
-            alias: alias ?? [],
-
+            conditionNames,
+            mainFields,
+            mainFiles,
             fallback: nodeBuiltinFallback,
+        }
+
+        if (this.options.extensions) {
+            this.resolverConfig.extensions = this.options.extensions
+        }
+
+        if (isTypescript(this.context)) {
+            this.resolverConfig.alias = getTSConfigAliases(this.context)
+            this.resolverConfig.extensionAlias = getTypescriptExtensionMap(
+                this.context
+            ).backward
         }
 
         const requireResolve = resolver.create.sync(this.resolverConfig)

--- a/lib/util/import-target.js
+++ b/lib/util/import-target.js
@@ -255,11 +255,11 @@ module.exports = class ImportTarget {
     }
 
     /**
-     * @param {string} baseDir
+     * @param {string} _baseDir
      * @param {unknown} error
      * @returns {void}
      */
-    handleResolutionError(baseDir, error) {
+    handleResolutionError(_baseDir, error) {
         if (error instanceof Error === false) {
             throw error
         }
@@ -304,13 +304,13 @@ module.exports = class ImportTarget {
 
         /** @type {import('enhanced-resolve').ResolveOptionsOptionalFS} */
         this.resolverConfig = {
-            conditionNames,
-            extensions,
-            mainFields,
-            mainFiles,
+            conditionNames: conditionNames,
+            extensions: extensions ?? [],
+            mainFields: mainFields ?? [],
+            mainFiles: mainFiles ?? [],
 
-            extensionAlias,
-            alias,
+            extensionAlias: extensionAlias ?? {},
+            alias: alias ?? [],
 
             fallback: nodeBuiltinFallback,
         }

--- a/lib/util/map-typescript-extension.js
+++ b/lib/util/map-typescript-extension.js
@@ -20,7 +20,12 @@ function convertTsExtensionToJs(context, filePath, fallbackExtension) {
     const { forward } = getTypescriptExtensionMap(context)
     const ext = path.extname(filePath)
 
-    if (isTypescript(context) && ext in forward) {
+    if (
+        isTypescript(context) &&
+        ext in forward &&
+        Object.hasOwn(forward, ext) &&
+        typeof forward[ext] === "string"
+    ) {
         return forward[ext]
     }
 
@@ -43,7 +48,12 @@ function convertJsExtensionToTs(context, filePath, fallbackExtension) {
     const { backward } = getTypescriptExtensionMap(context)
     const ext = path.extname(filePath)
 
-    if (isTypescript(context) && Object.hasOwn(backward, ext)) {
+    if (
+        isTypescript(context) &&
+        ext in backward &&
+        Object.hasOwn(backward, ext) &&
+        Array.isArray(backward[ext])
+    ) {
         return backward[ext]
     }
 

--- a/lib/util/merge-visitors-in-place.js
+++ b/lib/util/merge-visitors-in-place.js
@@ -32,7 +32,6 @@ module.exports = function mergeVisitorsInPlace(visitor1, visitor2) {
 
         const handlers = [handler1, handler2]
 
-        // @ts-expect-error - This is because its expecting a function that can match all {Rule.RuleListener[string]} functions!
         visitor1[key] = Object.assign(dispatch.bind(null, handlers), {
             _handlers: handlers,
         })
@@ -44,7 +43,7 @@ module.exports = function mergeVisitorsInPlace(visitor1, visitor2) {
 /**
  * Dispatch all given functions with a node.
  * @param {function[]} handlers The function list to call.
- * @param {Node} node The AST node to be handled.
+ * @param {import('estree').Node} node The AST node to be handled.
  * @returns {void}
  */
 function dispatch(handlers, node) {

--- a/lib/util/visit-import.js
+++ b/lib/util/visit-import.js
@@ -78,7 +78,8 @@ module.exports = function visitImport(
             }
             if (
                 ignoreTypeImport === true &&
-                /** @type {ImportDeclaration} */ (node).importKind === "type"
+                "importKind" in node &&
+                node.importKind === "type"
             ) {
                 return
             }

--- a/lib/util/visit-require.js
+++ b/lib/util/visit-require.js
@@ -64,6 +64,10 @@ module.exports = function visitRequire(
                 }
 
                 const targetNode = node.arguments[0]
+                if (targetNode == null) {
+                    continue
+                }
+
                 const rawName = getStringIfConstant(targetNode)
                 if (typeof rawName !== "string") {
                     continue

--- a/tests/lib/configs/eslintrc.js
+++ b/tests/lib/configs/eslintrc.js
@@ -14,7 +14,7 @@ function clearRequireCache() {
 
 describe("node/recommended config", () => {
     describe("in CJS directory", () => {
-        const root = path.resolve(__dirname, "../../fixtures/configs/cjs")
+        const root = path.resolve(__dirname, "../../fixtures/configs/cjs/")
 
         /** @type {Linter} */
         let linter = null
@@ -92,7 +92,7 @@ describe("node/recommended config", () => {
     })
 
     describe("in ESM directory", () => {
-        const root = path.resolve(__dirname, "../../fixtures/configs/esm")
+        const root = path.resolve(__dirname, "../../fixtures/configs/esm/")
 
         /** @type {Linter} */
         let linter = null

--- a/tests/lib/configs/eslintrc.js
+++ b/tests/lib/configs/eslintrc.js
@@ -14,7 +14,7 @@ function clearRequireCache() {
 
 describe("node/recommended config", () => {
     describe("in CJS directory", () => {
-        const root = path.resolve(__dirname, "../../fixtures/configs/cjs/")
+        const root = path.resolve(__dirname, "../../fixtures/configs/cjs")
 
         /** @type {Linter} */
         let linter = null
@@ -92,7 +92,7 @@ describe("node/recommended config", () => {
     })
 
     describe("in ESM directory", () => {
-        const root = path.resolve(__dirname, "../../fixtures/configs/esm/")
+        const root = path.resolve(__dirname, "../../fixtures/configs/esm")
 
         /** @type {Linter} */
         let linter = null

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,24 +1,40 @@
 {
+    "$schema": "https://json.schemastore.org/tsconfig",
     "compilerOptions": {
+        "rootDir": "./lib",
+        "declarationDir": "./types",
+
         "target": "es2022",
-        "moduleResolution": "node16",
-
+        "lib": ["es2023"],
         "module": "nodenext",
-
+        "moduleResolution": "nodenext",
+        "declaration": true,
+        "emitDeclarationOnly": true,
         "allowJs": true,
         "checkJs": true,
 
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "declarationDir": "./types",
-
         "allowSyntheticDefaultImports": false,
         "esModuleInterop": true,
+
         "resolveJsonModule": true,
+        "inlineSourceMap": true,
+        "inlineSources": true,
+        "noEmitHelpers": true,
+        "noEmitOnError": true,
+        "forceConsistentCasingInFileNames": true,
 
         "strict": true,
-        "skipDefaultLibCheck": false,
-        "skipLibCheck": false
+        "allowUnusedLabels": false,
+        "allowUnreachableCode": false,
+        "exactOptionalPropertyTypes": true,
+        "noFallthroughCasesInSwitch": true,
+        "noUncheckedIndexedAccess": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+
+        "isolatedModules": true,
+
+        "skipLibCheck": true
     },
     "include": ["./lib/eslint-utils.d.ts"],
     "files": ["./lib/index.js"]


### PR DESCRIPTION
This adds a much stricter tsconfig. 

It looks like this does now correctly export the types too.
<img width="608" alt="image" src="https://github.com/user-attachments/assets/f6f7d308-2745-4533-8c7d-75bdfb679e3c">
