### PR TITLE
feat(no-unsupported): Support node 23.1.0

### DIFF
--- a/lib/unsupported-features/node-builtins-modules/test.js
+++ b/lib/unsupported-features/node-builtins-modules/test.js
@@ -38,7 +38,7 @@ const test = {
     MockFunctionContext: { [READ]: { supported: ["19.1.0", "18.13.0"] } },
     MockModuleContext: { [READ]: { experimental: ["22.3.0"] } },
     MockTracker: { [READ]: { supported: ["19.1.0", "18.13.0"] } },
-    MockTimers: { [READ]: { experimental: ["20.4.0"] } },
+    MockTimers: { [READ]: { experimental: ["20.4.0"], supported: ["23.1.0"] } },
     TestsStream: { [READ]: { supported: ["18.9.0", "16.19.0"] } },
     TestContext: { [READ]: { supported: ["18.0.0", "16.17.0"] } },
     SuiteContext: { [READ]: { supported: ["18.7.0", "16.17.0"] } },

--- a/lib/unsupported-features/node-builtins-modules/util.js
+++ b/lib/unsupported-features/node-builtins-modules/util.js
@@ -91,6 +91,7 @@ const util = {
     getCallSite: { [READ]: { experimental: ["22.9.0"] } },
     getSystemErrorName: { [READ]: { supported: ["9.7.0", "8.12.0"] } },
     getSystemErrorMap: { [READ]: { supported: ["16.0.0", "14.17.0"] } },
+    getSystemErrorMessage: { [READ]: { supported: ["23.1.0"] } },
     inherits: { [READ]: { supported: ["0.3.0"] } },
     inspect: {
         [READ]: { supported: ["0.3.0"] },


### PR DESCRIPTION
Supported:
- [`test.MockTimers`](https://nodejs.org/docs/v23.1.0/api/test.html#class-mocktimers)
- [`util.getSystemErrorMessage`](https://nodejs.org/docs/v23.1.0/api/util.html#utilgetsystemerrormessageerr)