### PR TITLE
fix: exported / referenced plugin same instance

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -86,8 +86,4 @@ const configs = {
 }
 
 /** @type {ESLint.Plugin & { configs: Configs }} */
-module.exports = {
-    meta: base.meta,
-    rules: base.rules,
-    configs: configs,
-}
+module.exports = Object.assign(base, { configs })


### PR DESCRIPTION
It's important that the exported plugin reference and the one used in the exported configs are the very same – else one will get an error like:

> ConfigError: Config "node/flat/recommended-module": Key "plugins": Cannot redefine plugin "n".

This since two plugins are only allowed to have the same key if they are `===` to one another. See: https://github.com/eslint/eslint/blob/0583c87c720afe0b9aef5367b1a0a77923eefe9d/lib/config/flat-config-schema.js#L373-L375

This caused a regression for me in https://github.com/voxpelli/eslint-config/blob/638bbad2580bc4246527a6f0d989dc8194547475/base-configs/node.js#L10