### PR TITLE
fix(no-unsupported): Correctly handle recursive objects on a per module basis

### DIFF
--- a/lib/util/enumerate-property-names.js
+++ b/lib/util/enumerate-property-names.js
@@ -15,15 +15,16 @@ const unprefixNodeColon = require("./unprefix-node-colon")
  * Enumerate property names of a given object recursively.
  * @param {TraceMap} traceMap The map for APIs to enumerate.
  * @param {string[]} [path] The path to the current map.
- * @param {WeakSet<TraceMap>} [recursionSet] A WeakSet used to block recursion (eg Module, Module.Module, Module.Module.Module)
+ * @param {{ [key: string]: WeakSet<TraceMap> }} [recursion] An object to block recursion (per module)
  * @returns {IterableIterator<string>} The property names of the map.
  */
-function* enumeratePropertyNames(
-    traceMap,
-    path = [],
-    recursionSet = new WeakSet()
-) {
-    if (recursionSet.has(traceMap)) {
+function* enumeratePropertyNames(traceMap, path = [], recursion = {}) {
+    const recursionSet =
+        typeof path[0] === "string"
+            ? (recursion[path[0]] ??= new WeakSet())
+            : undefined
+
+    if (recursionSet?.has(traceMap)) {
         return
     }
 
@@ -48,11 +49,8 @@ function* enumeratePropertyNames(
             yield childName
         }
 
-        yield* enumeratePropertyNames(
-            childValue,
-            childPath,
-            recursionSet.add(traceMap)
-        )
+        recursionSet?.add(traceMap)
+        yield* enumeratePropertyNames(childValue, childPath, recursion)
     }
 }
 


### PR DESCRIPTION
Closes #395

This prevents the recusrion protection from blocking module alias publishing.

We look to have been missing 6 options from the ignores list :scream: 

|  | Valid `ignores` Count |
| --- | --- |
| Before | `1462` |
| After | `1468` |