### PR TITLE
fix Promise.withResolvers is supported since node 22.11

### DIFF
--- a/lib/rules/no-unsupported-features/es-syntax.json
+++ b/lib/rules/no-unsupported-features/es-syntax.json
@@ -437,7 +437,7 @@
         "supported": ">=10.0.0"
     },
     "no-promise-withresolvers": {
-        "supported": null
+        "supported": ">=22.11.0"
     },
     "no-promise": {
         "supported": ">=0.12.0"


### PR DESCRIPTION
Hello, 

Promise.withResolvers is supported since node 22.11 but current config does not allow it.

<img width="964" alt="image" src="https://github.com/user-attachments/assets/7fd931a2-27f4-4a00-bab3-fb910817d7db" />

[node.green](https://node.green/)