### PR TITLE
fix: False-positive `no-extraneous-import` when using the `tsconfig > paths` alias import

### DIFF
--- a/lib/util/import-target.js
+++ b/lib/util/import-target.js
@@ -176,6 +176,20 @@ module.exports = class ImportTarget {
             return "node"
         }
 
+        // This check should be done before the RegExp that checks npm packages,
+        // because `tsconfig.json` aliases may start with `~`, `@` and this will
+        // cause imports using aliases to be treated as npm-module imports
+        // https://github.com/eslint-community/eslint-plugin-n/issues/379
+        if (isTypescript(this.context)) {
+            const aliases = getTSConfigAliases(this.context)
+            if (
+                Array.isArray(aliases) &&
+                aliases.some(alias => this.name.startsWith(alias.name))
+            ) {
+                return "relative"
+            }
+        }
+
         if (/^(@[\w~-][\w.~-]*\/)?[\w~-][\w.~-]*/.test(this.name)) {
             return "npm"
         }

--- a/tests/fixtures/no-extraneous/tsconfig-paths/index.ts
+++ b/tests/fixtures/no-extraneous/tsconfig-paths/index.ts
@@ -1,0 +1,1 @@
+// File needs to exists

--- a/tests/fixtures/no-extraneous/tsconfig-paths/src/configurations/foo.ts
+++ b/tests/fixtures/no-extraneous/tsconfig-paths/src/configurations/foo.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/tests/fixtures/no-extraneous/tsconfig-paths/tsconfig.json
+++ b/tests/fixtures/no-extraneous/tsconfig-paths/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "paths": {
+            "~configurations/*": ["./src/configurations/*"],
+            "@configurations/*": ["./src/configurations/*"],
+            "#configurations/*": ["./src/configurations/*"]
+        }
+    }
+}

--- a/tests/lib/rules/no-extraneous-import.js
+++ b/tests/lib/rules/no-extraneous-import.js
@@ -33,6 +33,11 @@ function fixture(name) {
 
 const ruleTester = new RuleTester({
     languageOptions: { sourceType: "module" },
+    settings: {
+        n: {
+            tryExtensions: [".ts"],
+        },
+    },
 })
 ruleTester.run("no-extraneous-import", rule, {
     valid: [
@@ -77,6 +82,21 @@ ruleTester.run("no-extraneous-import", rule, {
         {
             filename: fixture("dependencies/a.js"),
             code: "import ccc from 'ccc'",
+        },
+
+        // imports using `tsconfig.json > compilerOptions > paths` setting
+        // https://github.com/eslint-community/eslint-plugin-n/issues/379
+        {
+            filename: fixture("tsconfig-paths/index.ts"),
+            code: "import foo from '@configurations/foo'",
+        },
+        {
+            filename: fixture("tsconfig-paths/index.ts"),
+            code: "import foo from '~configurations/foo'",
+        },
+        {
+            filename: fixture("tsconfig-paths/index.ts"),
+            code: "import foo from '#configurations/foo'",
         },
     ],
     invalid: [


### PR DESCRIPTION
Closes #379 

I decided to be as minimalistic as possible in the changes (still, it fixes the problem) :)

The original solution proposed in the issue didn't work for me, because calculating `resolverConfig` depends on `moduleType`, but calculating the correct `moduleType` requires partially filling `resolverConfig` (in particular `resolverConfig.alias`), which would result in calling a separate method twice, which is obviously less performant, so I just inserted the necessary check into the `getModuleType` definition.