### PR TITLE
chore(package): explicitly declare js module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
     },
     "main": "lib/index.js",
+    "type": "commonjs",
     "types": "types/index.d.ts",
     "files": [
         "lib/",


### PR DESCRIPTION
[Node 21.1.0 added a flag to detect module types](https://github.com/nodejs/node/releases/tag/v21.1.0) that became enabled by [default in Node 22.7.0](https://nodejs.org/api/packages.html#syntax-detection).
Declaring the type will cause Node to skip detection on startup, reducing startup time.

Declaring the package type is also considered good practice according to https://nodejs.org/api/modules.html#enabling.