### PR TITLE
feat(node-builtin): Add support for import.meta properties

### DIFF
--- a/lib/eslint-utils.d.ts
+++ b/lib/eslint-utils.d.ts
@@ -24,6 +24,7 @@ declare module "@eslint-community/eslint-utils" {
         iterateGlobalReferences<Info extends unknown>(traceMap: TraceMap<Info>): IterableIterator<Reference<Info>>;
         iterateCjsReferences<Info extends unknown>(traceMap: TraceMap<Info>): IterableIterator<Reference<Info>>;
         iterateEsmReferences<Info extends unknown>(traceMap: TraceMap<Info>): IterableIterator<Reference<Info>>;
+        iteratePropertyReferences<Info extends unknown>(node: estree.Expression, traceMap: TraceMap<Info>): IterableIterator<Reference<Info>>;
     }
     export namespace ReferenceTracker {
         export { READ };

--- a/lib/rules/no-unsupported-features/node-builtins.js
+++ b/lib/rules/no-unsupported-features/node-builtins.js
@@ -84,7 +84,6 @@ module.exports = {
                     return
                 }
 
-                tracker.iterateEsmReferences
                 const references = [
                     ...tracker.iteratePropertyReferences(
                         node,

--- a/lib/rules/no-unsupported-features/node-builtins.js
+++ b/lib/rules/no-unsupported-features/node-builtins.js
@@ -4,16 +4,20 @@
  */
 "use strict"
 
+const { ReferenceTracker } = require("@eslint-community/eslint-utils")
 const {
     checkUnsupportedBuiltins,
+    checkUnsupportedBuiltinReferences,
     messages,
 } = require("../../util/check-unsupported-builtins")
 const enumeratePropertyNames = require("../../util/enumerate-property-names")
 const getConfiguredNodeVersion = require("../../util/get-configured-node-version")
+const { getSourceCode } = require("../../util/eslint-compat")
 
 const {
     NodeBuiltinGlobals,
     NodeBuiltinModules,
+    NodeBuiltinImportMeta,
 } = require("../../unsupported-features/node-builtins.js")
 
 const traceMap = {
@@ -45,6 +49,11 @@ module.exports = {
                                 new Set([
                                     ...enumeratePropertyNames(traceMap.globals),
                                     ...enumeratePropertyNames(traceMap.modules),
+                                    ...[
+                                        ...enumeratePropertyNames(
+                                            NodeBuiltinImportMeta
+                                        ),
+                                    ].map(s => `import.meta.${s}`),
                                 ])
                             ),
                         },
@@ -57,9 +66,37 @@ module.exports = {
         messages,
     },
     create(context) {
+        const sourceCode = getSourceCode(context)
+        const tracker = new ReferenceTracker(
+            /** @type {NonNullable<typeof sourceCode.scopeManager.globalScope>} */ (
+                sourceCode.scopeManager.globalScope
+            )
+        )
         return {
             "Program:exit"() {
                 checkUnsupportedBuiltins(context, traceMap)
+            },
+            "MetaProperty:exit"(node) {
+                if (
+                    node.meta.name !== "import" ||
+                    node.property.name !== "meta"
+                ) {
+                    return
+                }
+
+                tracker.iterateEsmReferences
+                const references = [
+                    ...tracker.iteratePropertyReferences(
+                        node,
+                        NodeBuiltinImportMeta
+                    ),
+                ].map(reference => {
+                    return {
+                        ...reference,
+                        path: ["import.meta", ...reference.path],
+                    }
+                })
+                checkUnsupportedBuiltinReferences(context, references)
             },
         }
     },

--- a/lib/unsupported-features/node-builtins.js
+++ b/lib/unsupported-features/node-builtins.js
@@ -1,6 +1,7 @@
 "use strict"
 
 const NodeBuiltinGlobals = require("./node-globals.js")
+const NodeBuiltinImportMeta = require("./node-import-meta.js")
 
 /**
  * @type {import('./types.js').SupportVersionTraceMap}
@@ -50,4 +51,8 @@ const NodeBuiltinModules = {
     ...require("./node-builtins-modules/zlib.js"),
 }
 
-module.exports = { NodeBuiltinGlobals, NodeBuiltinModules }
+module.exports = {
+    NodeBuiltinGlobals,
+    NodeBuiltinModules,
+    NodeBuiltinImportMeta,
+}

--- a/lib/unsupported-features/node-import-meta.js
+++ b/lib/unsupported-features/node-import-meta.js
@@ -1,0 +1,27 @@
+"use strict"
+
+const { READ } = require("@eslint-community/eslint-utils")
+
+/**
+ * @type {import('./types.js').SupportVersionTraceMap}
+ */
+const importMeta = {
+    resolve: {
+        [READ]: {
+            supported: ["18.19.0", "20.6.0"],
+            experimental: ["12.16.2", "13.9.0"],
+        },
+    },
+    dirname: {
+        [READ]: {
+            supported: ["21.2.0", "20.11.0"],
+        },
+    },
+    filename: {
+        [READ]: {
+            supported: ["21.2.0", "20.11.0"],
+        },
+    },
+}
+
+module.exports = importMeta

--- a/lib/util/check-unsupported-builtins.js
+++ b/lib/util/check-unsupported-builtins.js
@@ -80,23 +80,13 @@ function versionsToString(versions) {
 }
 
 /**
- * Verify the code to report unsupported APIs.
+ * Verify the code to report unsupported API references.
  * @param {import('eslint').Rule.RuleContext} context The rule context.
- * @param {import('../unsupported-features/types.js').SupportVersionBuiltins} traceMap The map for APIs to report.
+ * @param {import("@eslint-community/eslint-utils").Reference<import("../unsupported-features/types.js").SupportInfo>[]} references The references for APIs to report.
  * @returns {void}
  */
-module.exports.checkUnsupportedBuiltins = function checkUnsupportedBuiltins(
-    context,
-    traceMap
-) {
+function checkUnsupportedBuiltinReferences(context, references) {
     const options = parseOptions(context)
-    const scope = getScope(context)
-    const tracker = new ReferenceTracker(scope, { mode: "legacy" })
-    const references = [
-        ...tracker.iterateCjsReferences(traceMap.modules ?? {}),
-        ...tracker.iterateEsmReferences(traceMap.modules ?? {}),
-        ...tracker.iterateGlobalReferences(traceMap.globals ?? {}),
-    ]
 
     for (const { node, path, info } of references) {
         const name = unprefixNodeColon(path.join("."))
@@ -153,6 +143,30 @@ module.exports.checkUnsupportedBuiltins = function checkUnsupportedBuiltins(
         })
     }
 }
+
+/**
+ * Verify the code to report unsupported APIs.
+ * @param {import('eslint').Rule.RuleContext} context The rule context.
+ * @param {import('../unsupported-features/types.js').SupportVersionBuiltins} traceMap The map for APIs to report.
+ * @returns {void}
+ */
+module.exports.checkUnsupportedBuiltins = function checkUnsupportedBuiltins(
+    context,
+    traceMap
+) {
+    const scope = getScope(context)
+    const tracker = new ReferenceTracker(scope, { mode: "legacy" })
+    const references = [
+        ...tracker.iterateCjsReferences(traceMap.modules ?? {}),
+        ...tracker.iterateEsmReferences(traceMap.modules ?? {}),
+        ...tracker.iterateGlobalReferences(traceMap.globals ?? {}),
+    ]
+
+    checkUnsupportedBuiltinReferences(context, references)
+}
+
+module.exports.checkUnsupportedBuiltinReferences =
+    checkUnsupportedBuiltinReferences
 
 exports.messages = {
     "not-experimental-till": [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "eslint": ">=8.23.0"
     },
     "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.1",
+        "@eslint-community/eslint-utils": "^4.5.0",
         "enhanced-resolve": "^5.17.1",
         "eslint-plugin-es-x": "^7.8.0",
         "get-tsconfig": "^4.8.1",

--- a/tests/lib/rules/no-unsupported-features/node-builtins.js
+++ b/tests/lib/rules/no-unsupported-features/node-builtins.js
@@ -5458,6 +5458,136 @@ new RuleTester({ languageOptions: { sourceType: "module" } }).run(
             ],
         },
 
+        //----------------------------------------------------------------------
+        // import.meta
+        //----------------------------------------------------------------------
+        {
+            valid: [
+                ...[
+                    { version: "22.0.0" },
+                    { version: "20.6.0" },
+                    { version: "18.19.0" },
+                    { version: "13.9.0", allowExperimental: true },
+                    { version: "12.16.2", allowExperimental: true },
+                    { version: "18.18.0", ignores: ["import.meta.resolve"] },
+                ].map(option => {
+                    return {
+                        code: "import.meta.resolve(specifier)",
+                        options: [option],
+                        languageOptions: { ecmaVersion: "latest" },
+                    }
+                }),
+                ...[
+                    { version: "22.0.0" },
+                    { version: "21.2.0" },
+                    { version: "20.11.0" },
+                    { version: "20.10.0", ignores: ["import.meta.dirname"] },
+                ].map(option => {
+                    return {
+                        code: "import.meta.dirname;",
+                        options: [option],
+                        languageOptions: { ecmaVersion: "latest" },
+                    }
+                }),
+                ...[
+                    { version: "22.0.0" },
+                    { version: "21.2.0" },
+                    { version: "20.11.0" },
+                    { version: "20.10.0", ignores: ["import.meta.filename"] },
+                ].map(option => {
+                    return {
+                        code: "import.meta.filename;",
+                        options: [option],
+                        languageOptions: { ecmaVersion: "latest" },
+                    }
+                }),
+            ],
+            invalid: [
+                ...[
+                    { version: "20.5.0" },
+                    { version: "19.8.1" },
+                    { version: "18.18.0" },
+                ].map(option => {
+                    return {
+                        code: "import.meta.resolve(specifier)",
+                        options: [option],
+                        languageOptions: { ecmaVersion: "latest" },
+                        errors: [
+                            {
+                                messageId: "not-supported-till",
+                                data: {
+                                    name: "import.meta.resolve",
+                                    supported: "20.6.0 (backported: ^18.19.0)",
+                                    version: option.version,
+                                },
+                            },
+                        ],
+                    }
+                }),
+                ...[
+                    { version: "13.8.0", allowExperimental: true },
+                    { version: "12.15.0", allowExperimental: true },
+                ].map(option => {
+                    return {
+                        code: "import.meta.resolve(specifier)",
+                        options: [option],
+                        languageOptions: { ecmaVersion: "latest" },
+                        errors: [
+                            {
+                                messageId: "not-experimental-till",
+                                data: {
+                                    name: "import.meta.resolve",
+                                    experimental:
+                                        "13.9.0 (backported: ^12.16.2)",
+                                    version: option.version,
+                                },
+                            },
+                        ],
+                    }
+                }),
+                ...[{ version: "21.1.0" }, { version: "20.10.0" }].map(
+                    option => {
+                        return {
+                            code: "import.meta.dirname;",
+                            options: [option],
+                            languageOptions: { ecmaVersion: "latest" },
+                            errors: [
+                                {
+                                    messageId: "not-supported-till",
+                                    data: {
+                                        name: "import.meta.dirname",
+                                        supported:
+                                            "21.2.0 (backported: ^20.11.0)",
+                                        version: option.version,
+                                    },
+                                },
+                            ],
+                        }
+                    }
+                ),
+                ...[{ version: "21.1.0" }, { version: "20.10.0" }].map(
+                    option => {
+                        return {
+                            code: "import.meta.filename;",
+                            options: [option],
+                            languageOptions: { ecmaVersion: "latest" },
+                            errors: [
+                                {
+                                    messageId: "not-supported-till",
+                                    data: {
+                                        name: "import.meta.filename",
+                                        supported:
+                                            "21.2.0 (backported: ^20.11.0)",
+                                        version: option.version,
+                                    },
+                                },
+                            ],
+                        }
+                    }
+                ),
+            ],
+        },
+
         {
             valid: [
                 {


### PR DESCRIPTION
This PR adds support for `import.meta` to the `no-unsupported-features/node-builtins` rule.

close #419