### PR TITLE
feat(allow-modules): include `virtual:` in the modules pattern

### DIFF
--- a/lib/util/get-allow-modules.js
+++ b/lib/util/get-allow-modules.js
@@ -53,7 +53,7 @@ module.exports.schema = {
     type: "array",
     items: {
         type: "string",
-        pattern: "^(?:@[a-zA-Z0-9_\\-.]+/)?[a-zA-Z0-9_\\-.]+$",
+        pattern: "^(?:virtual:)?(?:@[a-zA-Z0-9_\\-.]+/)?[a-zA-Z0-9_\\-.]+$",
     },
     uniqueItems: true,
 }

--- a/tests/lib/rules/no-extraneous-import.js
+++ b/tests/lib/rules/no-extraneous-import.js
@@ -98,6 +98,16 @@ ruleTester.run("no-extraneous-import", rule, {
             filename: fixture("tsconfig-paths/index.ts"),
             code: "import foo from '#configurations/foo'",
         },
+
+        // virtual modules
+        {
+            filename: fixture("test.js"),
+            code: "import a from 'virtual:package-name';",
+        },
+        {
+            filename: fixture("test.js"),
+            code: "import a from 'virtual:package-scope/name';",
+        },
     ],
     invalid: [
         {

--- a/tests/lib/rules/no-extraneous-require.js
+++ b/tests/lib/rules/no-extraneous-require.js
@@ -67,6 +67,16 @@ tester.run("no-extraneous-require", rule, {
             filename: fixture("dependencies/a.js"),
             code: "require('ccc')",
         },
+
+        // virtual modules
+        {
+            filename: fixture("test.js"),
+            code: "require('virtual:package-name');",
+        },
+        {
+            filename: fixture("test.js"),
+            code: "require('virtual:package-scope/name');",
+        },
     ],
     invalid: [
         {

--- a/tests/lib/rules/no-missing-import.js
+++ b/tests/lib/rules/no-missing-import.js
@@ -167,6 +167,17 @@ ruleTester.run("no-missing-import", rule, {
             code: "import electron from 'electron';",
             options: [{ allowModules: ["electron"] }],
         },
+        // allow virtual modules
+        {
+            filename: fixture("test.js"),
+            code: "import a from 'virtual:package-name';",
+            options: [{ allowModules: ["virtual:package-name"] }],
+        },
+        {
+            filename: fixture("test.js"),
+            code: "import a from 'virtual:package-scope/name';",
+            options: [{ allowModules: ["virtual:package-scope"] }],
+        },
 
         // resolvePaths
         {
@@ -480,5 +491,17 @@ ruleTester.run("no-missing-import", rule, {
                   },
               ]
             : []),
+
+        // virtual modules
+        {
+            filename: fixture("test.js"),
+            code: "import a from 'virtual:package-name';",
+            errors: cantResolve("virtual:package-name"),
+        },
+        {
+            filename: fixture("test.js"),
+            code: "import a from 'virtual:package-scope/name';",
+            errors: cantResolve("virtual:package-scope/name"),
+        },
     ],
 })

--- a/tests/lib/rules/no-missing-require.js
+++ b/tests/lib/rules/no-missing-require.js
@@ -240,6 +240,17 @@ ruleTester.run("no-missing-require", rule, {
             code: "require('jquery.cookie');",
             options: [{ allowModules: ["jquery.cookie"] }],
         },
+        // allow virtual modules
+        {
+            filename: fixture("test.js"),
+            code: "require('virtual:package-name');",
+            options: [{ allowModules: ["virtual:package-name"] }],
+        },
+        {
+            filename: fixture("test.js"),
+            code: "require('virtual:package-scope/name');",
+            options: [{ allowModules: ["virtual:package-scope"] }],
+        },
 
         // typescriptExtensionMap
         {
@@ -439,6 +450,18 @@ ruleTester.run("no-missing-require", rule, {
             filename: fixture("test.js"),
             code: "require.resolve('no-exist-package-0');",
             errors: cantResolve("no-exist-package-0"),
+        },
+
+        // Virtual modules
+        {
+            filename: fixture("test.js"),
+            code: "require('virtual:package-name');",
+            errors: cantResolve("virtual:package-name"),
+        },
+        {
+            filename: fixture("test.js"),
+            code: "require('virtual:package-scope/name');",
+            errors: cantResolve("virtual:package-scope/name"),
         },
     ],
 })

--- a/tests/lib/rules/no-unpublished-import.js
+++ b/tests/lib/rules/no-unpublished-import.js
@@ -123,10 +123,22 @@ ruleTester.run("no-unpublished-import", rule, {
             code: "import a from './a';",
         },
 
+        // allow module
         {
             filename: fixture("1/test.js"),
             code: "import electron from 'electron';",
             options: [{ allowModules: ["electron"] }],
+        },
+        // allow virtual modules
+        {
+            filename: fixture("test.js"),
+            code: "import a from 'virtual:package-name';",
+            options: [{ allowModules: ["virtual:package-name"] }],
+        },
+        {
+            filename: fixture("test.js"),
+            code: "import a from 'virtual:package-scope/name';",
+            options: [{ allowModules: ["virtual:package-scope"] }],
         },
 
         // Auto-published files only apply to root package directory

--- a/tests/lib/rules/no-unpublished-require.js
+++ b/tests/lib/rules/no-unpublished-require.js
@@ -224,6 +224,17 @@ ruleTester.run("no-unpublished-require", rule, {
             code: "require('electron');",
             options: [{ allowModules: ["electron"] }],
         },
+        // allow virtual modules
+        {
+            filename: fixture("test.js"),
+            code: "require('virtual:package-name');",
+            options: [{ allowModules: ["virtual:package-name"] }],
+        },
+        {
+            filename: fixture("test.js"),
+            code: "require('virtual:package-scope/name');",
+            options: [{ allowModules: ["virtual:package-scope"] }],
+        },
 
         // Auto-published files only apply to root package directory
         {


### PR DESCRIPTION
**Update Module Name Pattern to Support Virtual Modules**

**Description**
• Modified the regular expression pattern in the schema definition to allow an optional "virtual:" prefix. This update enables the configuration to recognize virtual modules.
• The updated pattern now supports module identifiers that may start with "virtual:" followed by optionally scoped names and the module name (e.g., "virtual:@scope/module" or "virtual:module").
• Existing validation behavior is preserved for standard module names, ensuring backward compatibility.
• No changes were made to the core logic; only the schema pattern expression has been updated.


