### PR TITLE
Allow to use `tryExtensions` in the rule `no-unpublished-import`

### DIFF
--- a/docs/rules/no-unpublished-import.md
+++ b/docs/rules/no-unpublished-import.md
@@ -51,6 +51,11 @@ Please see the shared settings documentation for more information.
 This can be configured in the rule options or as a shared setting [`settings.convertPath`](../shared-settings.md#convertpath).
 Please see the shared settings documentation for more information.
 
+#### tryExtensions
+
+This can be configured in the rule options or as a shared setting [`settings.tryExtensions`](../shared-settings.md#tryextensions).
+Please see the shared settings documentation for more information.
+
 ### ignoreTypeImport
 
 If using typescript, you may want to ignore type imports. This option allows you to do that.

--- a/lib/rules/no-unpublished-import.js
+++ b/lib/rules/no-unpublished-import.js
@@ -9,6 +9,7 @@ const getAllowModules = require("../util/get-allow-modules")
 const getConvertPath = require("../util/get-convert-path")
 const getResolvePaths = require("../util/get-resolve-paths")
 const getResolverConfig = require("../util/get-resolver-config")
+const getTryExtensions = require("../util/get-try-extensions")
 const visitImport = require("../util/visit-import")
 
 /**
@@ -18,6 +19,7 @@ const visitImport = require("../util/visit-import")
  *     convertPath?: import('../util/get-convert-path').ConvertPath;
  *     resolvePaths?: import('../util/get-resolve-paths').ResolvePaths;
  *     resolverConfig?: import('../util/get-resolver-config').ResolverConfig;
+ *     tryExtensions?: import('../util/get-try-extensions').TryExtensions;
  *     ignoreTypeImport?: boolean;
  *     ignorePrivate?: boolean;
  *   }?
@@ -42,6 +44,7 @@ module.exports = {
                     convertPath: getConvertPath.schema,
                     resolvePaths: getResolvePaths.schema,
                     resolverConfig: getResolverConfig.schema,
+                    tryExtensions: getTryExtensions.schema,
                     ignoreTypeImport: { type: "boolean", default: false },
                     ignorePrivate: { type: "boolean", default: true },
                 },

--- a/tests/fixtures/no-unpublished/4/package.json
+++ b/tests/fixtures/no-unpublished/4/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "test",
+    "version": "0.0.0",
+    "files": [
+        "index.jsx",
+        "abc.jsx"
+    ]
+}

--- a/tests/lib/rules/no-unpublished-import.js
+++ b/tests/lib/rules/no-unpublished-import.js
@@ -140,6 +140,16 @@ ruleTester.run("no-unpublished-import", rule, {
             code: "import a from 'virtual:package-scope/name';",
             options: [{ allowModules: ["virtual:package-scope"] }],
         },
+        // try extensions
+        {
+            filename: fixture("4/index.jsx"),
+            code: "import abc from './abc';",
+            options: [
+                {
+                    tryExtensions: [".jsx"],
+                },
+            ],
+        },
 
         // Auto-published files only apply to root package directory
         {
@@ -279,6 +289,16 @@ ruleTester.run("no-unpublished-import", rule, {
                 },
             ],
             errors: ['"../test.jsx" is not published.'],
+        },
+        // try extensions
+        {
+            filename: fixture("4/index.jsx"),
+            code: "import abc from './abc';",
+            errors: ['"./abc" is not published.'],
+            // Without setting tryExtensions, it defaults to [".js", ".json", ".node"], and thus
+            // cannot find the abc.jsx file, which is published.
+            //
+            // options: [{ tryExtensions: [".jsx"], }],
         },
 
         // outside of the package.


### PR DESCRIPTION
I just found that the option `tryExtensions` is available in `no-unpublished-require`, but not in `no-unpublished-import`. So I add this option.

Both `lib/util/visit-require.js` and `lib/util/visit-import.js` support this option, so this PR should work.

Here is my manual test:

1. Create an empty project.
2. Create `package.json` at the project root with only one line `{"files":["index.mts","foo.mts"]}`.
3. Create `index.mts` at the project root with only one line `import foo from './foo'; import bar from './bar';`.
4. Install eslint and eslint-plugin-n by `npm i -D eslint eslint-plugin-n`.
5. Create `eslint.config.mjs` at the project root.
   ```js
   import eslintPluginN from 'eslint-plugin-n'
   export default [{
     files: ['*.mts'],
     plugins: { n: eslintPluginN },
     // rules: { 'n/no-unpublished-import': ['error'] }
     rules: { 'n/no-unpublished-import': ['error', { tryExtensions: ['.mts'] }] } 
   }]
6. Run `npx eslint index.mts`.

Here is the test result:

|                                  | Without this PR | With this PR |
| -------------------------------- | --------------- | ------------- |
| Use commented rules in step 5.   | Got false error message: `error  "./foo" is not published`. | Same as left. |
| Use uncommented rules in step 5. | Got error message in step 6: `Unexpected property "tryExtensions"`. | Work as expected. |

I also tried with using tsconfig.json and path alias. It works smoothly.