### PR TITLE
feat(no-deprecated-api): Add support for `process.getBuiltinModule()`

### DIFF
--- a/lib/rules/no-deprecated-api.js
+++ b/lib/rules/no-deprecated-api.js
@@ -16,6 +16,9 @@ const getSemverRange = require("../util/get-semver-range")
 const extendTrackmapWithNodePrefix = require("../util/extend-trackmap-with-node-prefix")
 const unprefixNodeColon = require("../util/unprefix-node-colon")
 const { getScope } = require("../util/eslint-compat")
+const {
+    iterateProcessGetBuiltinModuleReferences,
+} = require("../util/iterate-process-get-builtin-module-references")
 
 /** @typedef {import('../unsupported-features/types.js').DeprecatedInfo} DeprecatedInfo */
 /**
@@ -842,6 +845,10 @@ module.exports = {
                 }
                 for (const report of [
                     ...tracker.iterateCjsReferences(modules),
+                    ...iterateProcessGetBuiltinModuleReferences(
+                        tracker,
+                        modules
+                    ),
                     ...tracker.iterateEsmReferences(modules),
                 ]) {
                     const { node, path, type, info } = report

--- a/lib/util/iterate-process-get-builtin-module-references.js
+++ b/lib/util/iterate-process-get-builtin-module-references.js
@@ -1,0 +1,56 @@
+"use strict"
+const {
+    CALL,
+    getStringIfConstant,
+    READ,
+} = require("@eslint-community/eslint-utils")
+const processGetBuiltinModuleCall = {
+    process: {
+        getBuiltinModule: {
+            [CALL]: true,
+        },
+    },
+}
+/**
+ * Iterate the references of process.getBuiltinModule() modules.
+ * @template Info
+ * @param {import("@eslint-community/eslint-utils").ReferenceTracker} tracker The reference tracker.
+ * @param {import("@eslint-community/eslint-utils").TraceMap<Info>} traceMap The trace map.
+ * @returns {IterableIterator<import("@eslint-community/eslint-utils").Reference<Info>>} The iterator.
+ */
+function* iterateProcessGetBuiltinModuleReferences(tracker, traceMap) {
+    for (const { node } of tracker.iterateGlobalReferences(
+        processGetBuiltinModuleCall
+    )) {
+        if (node.type !== "CallExpression") continue
+        const key = node.arguments[0] && getStringIfConstant(node.arguments[0])
+        if (key == null) {
+            continue
+        }
+        const nextTraceMap = Object.hasOwn(traceMap, key) && traceMap[key]
+        if (!nextTraceMap) {
+            continue
+        }
+
+        if (nextTraceMap[READ]) {
+            yield {
+                node,
+                path: [key],
+                type: READ,
+                info: nextTraceMap[READ],
+            }
+        }
+
+        for (const ref of tracker.iteratePropertyReferences(
+            node,
+            nextTraceMap
+        )) {
+            yield {
+                ...ref,
+                path: [key, ...ref.path],
+            }
+        }
+    }
+}
+
+module.exports = { iterateProcessGetBuiltinModuleReferences }

--- a/tests/lib/rules/no-deprecated-api.js
+++ b/tests/lib/rules/no-deprecated-api.js
@@ -42,6 +42,12 @@ ruleTester.run("no-deprecated-api", rule, {
             code: "import {request} from 'http'; request()",
             languageOptions: { sourceType: "module" },
         },
+        {
+            code: "const {Buffer} = process.getBuiltinModule('another-buffer'); new Buffer()",
+        },
+        {
+            code: "const {request} = process.getBuiltinModule('http'); request()",
+        },
 
         // On Node v6.8.0, fs.existsSync revived.
         {
@@ -758,6 +764,92 @@ ruleTester.run("no-deprecated-api", rule, {
         },
         {
             code: "require('module').createRequireFromPath()",
+            options: [{ version: "12.2.0" }],
+            errors: [
+                "'module.createRequireFromPath' was deprecated since v12.2.0. Use 'module.createRequire()' instead.",
+            ],
+        },
+
+        // process.getBuiltinModule()
+        {
+            code: "const b = process.getBuiltinModule('buffer'); new b.Buffer()",
+            options: [{ version: "6.0.0" }],
+            errors: [
+                "'new buffer.Buffer()' was deprecated since v6.0.0. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' instead.",
+            ],
+        },
+        {
+            code: "const b = process.getBuiltinModule('node:buffer'); new b.Buffer()",
+            options: [{ version: "6.0.0" }],
+            errors: [
+                "'new buffer.Buffer()' was deprecated since v6.0.0. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' instead.",
+            ],
+        },
+        {
+            code: "const {Buffer} = process.getBuiltinModule('buffer'); new Buffer()",
+            options: [{ version: "6.0.0" }],
+            errors: [
+                "'new buffer.Buffer()' was deprecated since v6.0.0. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' instead.",
+            ],
+        },
+        {
+            code: "const {Buffer:b} = process.getBuiltinModule('buffer'); new b()",
+            options: [{ version: "6.0.0" }],
+            errors: [
+                "'new buffer.Buffer()' was deprecated since v6.0.0. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' instead.",
+            ],
+        },
+        {
+            code: "const b = process.getBuiltinModule('buffer'); b.SlowBuffer",
+            options: [{ version: "6.0.0" }],
+            errors: [
+                "'buffer.SlowBuffer' was deprecated since v6.0.0. Use 'buffer.Buffer.allocUnsafeSlow()' instead.",
+            ],
+        },
+        {
+            code: "const domain = process.getBuiltinModule('domain');",
+            options: [{ version: "4.0.0" }],
+            languageOptions: { sourceType: "module" },
+            errors: ["'domain' module was deprecated since v4.0.0."],
+        },
+
+        {
+            code: "new (process.getBuiltinModule('buffer').Buffer)()",
+            options: [
+                {
+                    //
+                    ignoreModuleItems: ["buffer.Buffer()"],
+                    ignoreGlobalItems: ["Buffer()", "new Buffer()"],
+                    version: "6.0.0",
+                },
+            ],
+            errors: [
+                "'new buffer.Buffer()' was deprecated since v6.0.0. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' instead.",
+            ],
+        },
+        {
+            code: "process.getBuiltinModule('buffer').Buffer()",
+            options: [
+                {
+                    //
+                    ignoreModuleItems: ["new buffer.Buffer()"],
+                    ignoreGlobalItems: ["Buffer()", "new Buffer()"],
+                    version: "6.0.0",
+                },
+            ],
+            errors: [
+                "'buffer.Buffer()' was deprecated since v6.0.0. Use 'buffer.Buffer.alloc()' or 'buffer.Buffer.from()' instead.",
+            ],
+        },
+        {
+            code: "process.getBuiltinModule('module').createRequireFromPath()",
+            options: [{ version: "12.0.0" }],
+            errors: [
+                "'module.createRequireFromPath' was deprecated since v12.2.0.",
+            ],
+        },
+        {
+            code: "process.getBuiltinModule('module').createRequireFromPath()",
             options: [{ version: "12.2.0" }],
             errors: [
                 "'module.createRequireFromPath' was deprecated since v12.2.0. Use 'module.createRequire()' instead.",


### PR DESCRIPTION
Part of https://github.com/eslint-community/eslint-plugin-n/issues/428