### PR TITLE
feat(prefer-promises): Add support for `process.getBuiltinModule()`

### DIFF
--- a/lib/rules/prefer-promises/dns.js
+++ b/lib/rules/prefer-promises/dns.js
@@ -10,6 +10,9 @@ const {
     ReferenceTracker,
 } = require("@eslint-community/eslint-utils")
 const { getScope } = require("../../util/eslint-compat")
+const {
+    iterateProcessGetBuiltinModuleReferences,
+} = require("../../util/iterate-process-get-builtin-module-references")
 
 /** @type {import('@eslint-community/eslint-utils').TraceMap<boolean>} */
 const dns = {
@@ -63,6 +66,10 @@ module.exports = {
                 const tracker = new ReferenceTracker(scope, { mode: "legacy" })
                 const references = [
                     ...tracker.iterateCjsReferences(traceMap),
+                    ...iterateProcessGetBuiltinModuleReferences(
+                        tracker,
+                        traceMap
+                    ),
                     ...tracker.iterateEsmReferences(traceMap),
                 ]
 

--- a/lib/rules/prefer-promises/fs.js
+++ b/lib/rules/prefer-promises/fs.js
@@ -6,6 +6,9 @@
 
 const { CALL, ReferenceTracker } = require("@eslint-community/eslint-utils")
 const { getScope } = require("../../util/eslint-compat")
+const {
+    iterateProcessGetBuiltinModuleReferences,
+} = require("../../util/iterate-process-get-builtin-module-references")
 
 /** @type {import('@eslint-community/eslint-utils').TraceMap<boolean>} */
 const traceMap = {
@@ -61,6 +64,10 @@ module.exports = {
                 const tracker = new ReferenceTracker(scope, { mode: "legacy" })
                 const references = [
                     ...tracker.iterateCjsReferences(traceMap),
+                    ...iterateProcessGetBuiltinModuleReferences(
+                        tracker,
+                        traceMap
+                    ),
                     ...tracker.iterateEsmReferences(traceMap),
                 ]
 

--- a/tests/lib/rules/prefer-promises/dns.js
+++ b/tests/lib/rules/prefer-promises/dns.js
@@ -22,6 +22,10 @@ new RuleTester({
         "import * as dns from 'dns'; dns.promises.lookup()",
         "import {promises} from 'dns'; promises.lookup()",
         "import {promises as dns} from 'dns'; dns.lookup()",
+        "const dns = process.getBuiltinModule('dns'); dns.promises.lookup()",
+        "const dns = process.getBuiltinModule('node:dns'); dns.promises.lookup()",
+        "const {promises} = process.getBuiltinModule('dns'); promises.lookup()",
+        "const {promises: dns} = process.getBuiltinModule('dns'); dns.lookup()",
     ],
     invalid: [
         {
@@ -50,6 +54,18 @@ new RuleTester({
         },
         {
             code: "import {lookup} from 'dns'; lookup()",
+            errors: [{ messageId: "preferPromises", data: { name: "lookup" } }],
+        },
+        {
+            code: "const dns = process.getBuiltinModule('dns'); dns.lookup()",
+            errors: [{ messageId: "preferPromises", data: { name: "lookup" } }],
+        },
+        {
+            code: "const dns = process.getBuiltinModule('node:dns'); dns.lookup()",
+            errors: [{ messageId: "preferPromises", data: { name: "lookup" } }],
+        },
+        {
+            code: "const {lookup} = process.getBuiltinModule('dns'); lookup()",
             errors: [{ messageId: "preferPromises", data: { name: "lookup" } }],
         },
 

--- a/tests/lib/rules/prefer-promises/fs.js
+++ b/tests/lib/rules/prefer-promises/fs.js
@@ -23,6 +23,10 @@ new RuleTester({
         "import * as fs from 'fs'; fs.promises.access()",
         "import {promises} from 'fs'; promises.access()",
         "import {promises as fs} from 'fs'; fs.access()",
+        "const fs = process.getBuiltinModule('fs'); fs.promises.access()",
+        "const fs = process.getBuiltinModule('node:fs'); fs.promises.access()",
+        "const {promises} = process.getBuiltinModule('fs'); promises.access()",
+        "const {promises: fs} = process.getBuiltinModule('fs'); fs.access()",
     ],
     invalid: [
         {
@@ -51,6 +55,18 @@ new RuleTester({
         },
         {
             code: "import {access} from 'fs'; access()",
+            errors: [{ messageId: "preferPromises", data: { name: "access" } }],
+        },
+        {
+            code: "const fs = process.getBuiltinModule('fs'); fs.access()",
+            errors: [{ messageId: "preferPromises", data: { name: "access" } }],
+        },
+        {
+            code: "const fs = process.getBuiltinModule('node:fs'); fs.access()",
+            errors: [{ messageId: "preferPromises", data: { name: "access" } }],
+        },
+        {
+            code: "const {access} = process.getBuiltinModule('fs'); access()",
             errors: [{ messageId: "preferPromises", data: { name: "access" } }],
         },
 


### PR DESCRIPTION
Part of https://github.com/eslint-community/eslint-plugin-n/issues/428