### PR TITLE
fix(ci): Ignore type test failures for types present in ESLint 8 that we removed in ESLint 9.31.0

### DIFF
--- a/lib/rules/no-path-concat.js
+++ b/lib/rules/no-path-concat.js
@@ -198,6 +198,7 @@ module.exports = {
             "Program:exit"(programNode) {
                 const sourceCode = getSourceCode(context)
                 const globalScope =
+                    // @ts-ignore
                     sourceCode.getScope?.(programNode) ?? context.getScope()
                 const tracker = new ReferenceTracker(globalScope)
                 /** @type {Set<import('estree').Node>} */

--- a/lib/util/eslint-compat.js
+++ b/lib/util/eslint-compat.js
@@ -17,6 +17,7 @@ exports.getScope = function (
     /** @type {Node} */ node
 ) {
     const sourceCode = exports.getSourceCode(context)
+    // @ts-ignore
     return sourceCode.getScope?.(node || sourceCode.ast) || context.getScope()
 }
 
@@ -25,6 +26,7 @@ exports.getAncestors = function (
     /** @type {Node} */ node
 ) {
     const sourceCode = exports.getSourceCode(context)
+    // @ts-ignore
     return sourceCode.getAncestors?.(node) || context.getAncestors()
 }
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@types/node": "^20.17.5",
         "@typescript-eslint/parser": "^8.26.1",
         "@typescript-eslint/typescript-estree": "^8.26.1",
-        "eslint": "^9.14.0",
+        "eslint": "^9.31.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-doc-generator": "^1.7.1",
         "eslint-plugin-eslint-plugin": "^6.3.1",


### PR DESCRIPTION
eslint@9.31.0 removed some of the RuleContext types (see eslint/eslint#19910), causing the `test:types` CI script to fail.

Since `eslint-plugin-n` still needs to support 8.x versions of `eslint`, the implementation that relies on `RuleContext`s can't be removed.
    
A simple solution to unblock the CI is to annotate the few places that rely on them with `@ts-ignore`.
When `eslint` 8.x support is dropped, these annotations should be removed. That, in turn, will expose the code that relies on `eslint` 8.x APIs, which should then also be removed.
    
As part of this PR, the `eslint` dependency was bumped to `^9.31.0`.
This was done in order to prevent developers from developing locally with older 9.x versions of `eslint` and accidentally introducing new code that relies on these types without properly handling the type annotations and having it fail in the CI.


Fixes #459