### PR TITLE
refactor: remove minimatch dependency

### DIFF
--- a/lib/util/get-convert-path.js
+++ b/lib/util/get-convert-path.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const { Minimatch } = require("minimatch")
+const globrex = require("globrex")
 
 /**
  * @typedef PathConvertion
@@ -57,13 +57,10 @@ function normalizeValue(x) {
 
 /**
  * @param {string} pattern
- * @return {Minimatch}
+ * @return {globrex.Results}
  */
 function makeMatcher(pattern) {
-    const posix = pattern.replace(/\\/g, "/")
-    return new Minimatch(posix, {
-        allowWindowsEscape: true,
-    })
+    return globrex(pattern, { globstar: true })
 }
 
 /**
@@ -78,8 +75,8 @@ function createMatch(includePatterns, excludePatterns) {
     const exclude = excludePatterns.map(makeMatcher)
 
     return filePath =>
-        include.some(m => m.match(filePath)) &&
-        !exclude.some(m => m.match(filePath))
+        include.some(m => m.regex.test(filePath)) &&
+        !exclude.some(m => m.regex.test(filePath))
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
         "globals": "^15.11.0",
         "globrex": "^0.1.2",
         "ignore": "^5.3.2",
-        "minimatch": "^9.0.5",
         "semver": "^7.6.3",
         "ts-declaration-location": "^1.0.6"
     },


### PR DESCRIPTION
Follow up on #458 - as suggested in the PR discussion (see https://github.com/eslint-community/eslint-plugin-n/pull/458#issuecomment-3122682639), replace minimatch with globrex across the board, so we ship only one pattern matching dependency.