### PR TITLE
fix(no-missing-import): Support data imports

### DIFF
--- a/lib/util/import-target.js
+++ b/lib/util/import-target.js
@@ -74,7 +74,7 @@ function getTSConfigAliases(context) {
  * @property {Partial<import('enhanced-resolve').ResolveOptions>} [resolverConfig]
  * @property {string} basedir
  */
-/** @typedef { 'unknown' | 'relative' | 'absolute' | 'node' | 'npm' | 'http' } ModuleType */
+/** @typedef { 'unknown' | 'relative' | 'absolute' | 'node' | 'npm' | 'http' | 'data' } ModuleType */
 /** @typedef { 'import' | 'require' | 'type' } ModuleStyle */
 
 /**
@@ -176,6 +176,10 @@ module.exports = class ImportTarget {
             return "node"
         }
 
+        if (/^data:/.test(this.name)) {
+            return "data"
+        }
+
         if (/^(@[\w~-][\w.~-]*\/)?[\w~-][\w.~-]*/.test(this.name)) {
             return "npm"
         }
@@ -242,7 +246,7 @@ module.exports = class ImportTarget {
      * @returns {string | undefined}
      */
     getModuleName() {
-        if (this.moduleType === "relative") return
+        if (this.moduleType === "relative" || this.moduleType === "data") return
 
         if (this.moduleType === "npm") {
             if (this.name.startsWith("@")) {
@@ -296,6 +300,10 @@ module.exports = class ImportTarget {
      * @returns {string | null} The resolved path.
      */
     getFilePath() {
+        if (this.moduleType === "data" && this.moduleStyle === "import") {
+            return this.name
+        }
+
         const conditionNames = ["node", "require"]
 
         const mainFields = []

--- a/tests/lib/rules/no-missing-import.js
+++ b/tests/lib/rules/no-missing-import.js
@@ -366,6 +366,12 @@ ruleTester.run("no-missing-import", rule, {
             options: [{ ignoreTypeImport: true }],
         },
 
+        // data import
+        {
+            filename: fixture("test.js"),
+            code: "import 'data:text/javascript,const x = 123;';",
+        },
+
         // import()
         ...(DynamicImportSupported
             ? [

--- a/tests/lib/rules/no-missing-require.js
+++ b/tests/lib/rules/no-missing-require.js
@@ -463,6 +463,14 @@ ruleTester.run("no-missing-require", rule, {
             code: "require('virtual:package-scope/name');",
             errors: cantResolve("virtual:package-scope/name"),
         },
+
+        // Sanity test for (wrong) attempt to require data
+        // (this should only be supported in imports)
+        {
+            filename: fixture("test.js"),
+            code: "require('data:text/javascript,const x = 123;');",
+            errors: cantResolve("data:text/javascript,const x = 123;"),
+        },
     ],
 })
 


### PR DESCRIPTION
Imported prefixed with `data:` are not modules to be resolved, but the direct data that should be imported (e.g., JavaScript code, JSON or WASM).

This PR adds support for such imports in the no-missing-import rule.

Note:
With this change, the rule doesn't attempt to parse the data being imported, it merely does not try to resolve it to a path (which would fail), and thus allows those imports in the user's code.

Fixes #464