### PR TITLE
fix(ci): bump markdowncli-lint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "fast-glob": "^3.3.2",
         "husky": "^9.1.6",
         "lint-staged": "^15.2.10",
-        "markdownlint-cli": "^0.42.0",
+        "markdownlint-cli": "^0.45.0",
         "mocha": "^10.8.2",
         "npm-run-all2": "^6.2.6",
         "nyc": "^17.1.0",


### PR DESCRIPTION
Bump the `markdowncli-lint` version to the newest available version to solve the runtime deprecation warning about `f.R_OK`.

Fixes #467