### PR TITLE
fix(node-builtins-modules/tls.js): Update minimal version

### DIFF
--- a/lib/unsupported-features/node-builtins-modules/tls.js
+++ b/lib/unsupported-features/node-builtins-modules/tls.js
@@ -14,7 +14,7 @@ const tls = {
     },
     createServer: { [READ]: { supported: ["0.3.2"] } },
     CryptoStream: { [READ]: { supported: ["0.3.4"], deprecated: ["0.11.3"] } },
-    DEFAULT_CIPHERS: { [READ]: { supported: ["19.8.0", "18.16.0"] } },
+    DEFAULT_CIPHERS: { [READ]: { supported: ["0.11.3"] } },
     DEFAULT_ECDH_CURVE: { [READ]: { supported: ["0.11.13"] } },
     DEFAULT_MAX_VERSION: { [READ]: { supported: ["11.4.0"] } },
     DEFAULT_MIN_VERSION: { [READ]: { supported: ["11.4.0"] } },

--- a/tests/lib/rules/no-unsupported-features/node-builtins.js
+++ b/tests/lib/rules/no-unsupported-features/node-builtins.js
@@ -267,6 +267,10 @@ new RuleTester({ languageOptions: { sourceType: "module" } }).run(
                     code: "new Buffer(123)",
                     options: [{ version: "6.0.0" }],
                 },
+                {
+                    code: "require('tls').DEFAULT_CIPHERS",
+                    options: [{ version: "18.0.0" }],
+                },
             ],
             invalid: [
                 {


### PR DESCRIPTION
`tls.DEFAULT_CIPHERS` has been available since Node.js 0.11.3. This configuration has a faulty listing that was copied verbatim from a faulty listing in the Node.js documentation.
See https://github.com/nodejs/node/issues/59246 for additional details.

Fixes #483