### PR TITLE
fix: remove no-unpublished-bin from recommended

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ For [Shareable Configs](https://eslint.org/docs/latest/developer-guide/shareable
 | [no-restricted-require](docs/rules/no-restricted-require.md)                                 | disallow specified modules when loaded by `require`                         |      |    |    |
 | [no-sync](docs/rules/no-sync.md)                                                             | disallow synchronous methods                                                |      |    |    |
 | [no-top-level-await](docs/rules/no-top-level-await.md)                                       | disallow top-level `await` in published modules                             |      |    |    |
-| [no-unpublished-bin](docs/rules/no-unpublished-bin.md)                                       | disallow `bin` files that npm ignores                                       | 🟢 ✅ |    |    |
+| [no-unpublished-bin](docs/rules/no-unpublished-bin.md)                                       | disallow `bin` files that npm ignores                                       |      |    |    |
 | [no-unpublished-import](docs/rules/no-unpublished-import.md)                                 | disallow `import` declarations which import private modules                 | 🟢 ✅ |    |    |
 | [no-unpublished-require](docs/rules/no-unpublished-require.md)                               | disallow `require()` expressions which import private modules               | 🟢 ✅ |    |    |
 | [no-unsupported-features/es-builtins](docs/rules/no-unsupported-features/es-builtins.md)     | disallow unsupported ECMAScript built-ins on the specified version          | 🟢 ✅ |    |    |

--- a/docs/rules/no-unpublished-bin.md
+++ b/docs/rules/no-unpublished-bin.md
@@ -1,8 +1,8 @@
 # Disallow `bin` files that npm ignores (`n/no-unpublished-bin`)
 
-💼 This rule is enabled in the following [configs](https://github.com/eslint-community/eslint-plugin-n#-configs): 🟢 `recommended-module`, ✅ `recommended-script`.
-
 <!-- end auto-generated rule header -->
+
+Users can safely disable this rule if using npm v10 and later.
 
 We can publish CLI commands by `npm`. It uses `bin` field of `package.json`.
 
@@ -27,17 +27,19 @@ If `npm` ignores the files in `bin` field, this rule warns the files.
 ```json
 {
     "rules": {
-        "n/no-unpublished-bin": ["error", {
-            "convertPath": null
-        }]
+        "n/no-unpublished-bin": [
+            "error",
+            {
+                "convertPath": null
+            }
+        ]
     }
 }
 ```
 
 #### convertPath
 
-This can be configured in the rule options or as a shared setting [`settings.convertPath`](../shared-settings.md#convertpath).
-Please see the shared settings documentation for more information.
+This can be configured in the rule options or as a shared setting [`settings.convertPath`](../shared-settings.md#convertpath). Please see the shared settings documentation for more information.
 
 ## 🔎 Implementation
 

--- a/lib/rules/no-unpublished-bin.js
+++ b/lib/rules/no-unpublished-bin.js
@@ -15,7 +15,6 @@ module.exports = {
     meta: {
         docs: {
             description: "disallow `bin` files that npm ignores",
-            recommended: true,
             url: "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unpublished-bin.md",
         },
         type: "problem",


### PR DESCRIPTION
fixes: #472 

Removes no-unpublished-bin from recommended as it is no longer necessary in newer versions of npm.